### PR TITLE
feat(T0040+T0045): 死亡系统 + Toast降噪/战斗日志/弹窗增强

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -14,20 +14,23 @@
 | [T0020](tasks/todo/T0020-divine-arts.md) | 神通（元素体系） | T0017 ✅, T0018 ✅ | — | ⬜ |
 | [T0021](tasks/todo/T0021-map-system.md) | 地图系统 | T0001 ✅ | — | ⬜ |
 | [T0025](tasks/todo/T0025-npc-system.md) | NPC 系统 | T0001 ✅ | — | ⬜ |
-| [T0030](tasks/todo/T0030-reincarnation.md) | 转世重修 | T0029 ✅, T0040 | — | ⬜ |
+| [T0030](tasks/todo/T0030-reincarnation.md) | 转世重修 | T0029 ✅, T0040 ✅ | — | ⬜ |
 | [T0031](tasks/todo/T0031-achievement.md) | 成就系统 | T0001 ✅ | — | ⬜ |
 | [T0033](tasks/todo/T0033-ascension.md) | 仙道境界（飞升） | T0029 ✅ | — | ⬜ |
 | [T0035](tasks/todo/T0035-azure-cicd.md) | Azure SWA CI/CD | — | — | ⬜ |
 | [T0037](tasks/todo/T0037-audio.md) | 音效系统 | — | — | ⬜ |
 | [T0038](tasks/todo/T0038-multi-save.md) | 多存档 | — | — | ⬜ |
 | [T0039](tasks/todo/T0039-tutorial.md) | 新手引导 | T0001 ✅ | — | ⬜ |
-| [T0040](tasks/todo/T0040-death-system.md) | 死亡与复活系统 | T0001 ✅, T0003 ✅, T0012 ✅ | [spec](specs/T0040-death-system.md) | ⬜ |
+
+
 
 
 ## 最近完成
 
 | ID | 任务 | 完成日期 |
 |----|------|----------|
+| T0045 | Toast 降噪 + 战斗日志合并 | 2026-03-30 |
+| T0040 | 死亡与复活系统 | 2026-03-30 |
 | T0044 | 战斗弹窗 + 日志精简 | 2026-03-27 |
 | T0018 | 技能战斗 | 2026-03-27 |
 | T0043 | 日志系统改进（Toast + 时间线） | 2026-03-27 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,7 +84,7 @@
 |----|------|------|------|------|
 | [T0029](tasks/done/T0029-breakthrough-v2.md) | 突破系统重构 + 渡劫 | T0004, T0012 | [spec](specs/T0029-breakthrough-tribulation.md) | ✅ |
 | [T0030](tasks/todo/T0030-reincarnation.md) | 转世重修 | T0029, T0040 | — | ⬜ |
-| [T0040](tasks/todo/T0040-death-system.md) | 死亡与复活系统 | T0001, T0003, T0012, T0018, T0044 | [spec](specs/T0040-death-system.md) | ⬜ |
+| [T0040](tasks/done/T0040-death-system.md) | 死亡与复活系统 | T0001, T0003, T0012, T0018, T0044 | [spec](specs/T0040-death-system.md) | ✅ |
 | [T0031](tasks/todo/T0031-achievement.md) | 成就系统 | T0001 | — | ⬜ |
 | [T0032](tasks/todo/T0032-leaderboard.md) | 排行榜 | T0031 | — | ⬜ |
 | [T0033](tasks/todo/T0033-ascension.md) | 仙道境界（飞升） | T0029 | — | ⬜ |
@@ -98,6 +98,7 @@
 | [T0041](tasks/done/T0041-ui-layout-revamp.md) | 界面布局改版（三栏 + 头像） | T0006 | [spec](specs/T0041-ui-layout-revamp.md) | ✅ |
 | [T0043](tasks/done/T0043-log-revamp.md) | 日志系统改进（Toast + 时间线 + 功法增强） | T0011, T0042, T0017 | — | ✅ |
 | [T0044](tasks/done/T0044-combat-modal-log.md) | 战斗弹窗 + 日志精简 | T0003, T0043 | [spec](specs/T0044-combat-modal-log.md) | ✅ |
+| [T0045](tasks/done/T0045-toast-combat-log-polish.md) | Toast 降噪 + 战斗日志合并 | T0043, T0044 | [spec](specs/T0045-toast-combat-log-polish.md) | ✅ |
 
 ### 🏷️ 部署与体验
 

--- a/docs/specs/T0045-toast-combat-log-polish.md
+++ b/docs/specs/T0045-toast-combat-log-polish.md
@@ -1,0 +1,199 @@
+# 设计文档：Toast 降噪 + 战斗日志合并
+
+任务：T0045
+日期：2026-03-30
+
+## 概述
+
+用户反馈两个 UI 体验问题：
+1. **Toast 通知太突兀** — 每条日志都弹 Toast 气泡，多条堆叠视觉混乱
+2. **战斗日志太散** — 战斗结果中属性变化分散，缺少 HP/MP 等差值展示
+
+本任务统一改进消息反馈机制：降低 Toast 侵入性、合并战斗日志为结构化摘要。
+
+## 问题根因分析
+
+### Toast 根因
+
+`useGameEngine.ts` 中 `addLog()` 包装函数（第 93-99 行）对**所有**日志无条件调用 `showToast()`：
+
+```ts
+const addLog = useCallback((msg: string, category: LogCategory = 'default') => {
+    showToast(msg, category);          // ← 每条都弹
+    if (msg.startsWith('⚠️')) return;
+    rawAddLog(msg, category, ...);
+}, ...);
+```
+
+结果：修炼 / 战斗 / 探索 / 休息 / 炼丹 / 商店 / 日常事件… 每个操作至少 1 条 Toast，探索拾取物品时 2 条，加上日常事件可能再叠 1 条。最多 5 条 Toast 同时堆叠在屏幕顶部中央，视觉噪音极大。
+
+### 战斗日志根因
+
+`handleCombatClose` 胜利日志已是一行，但格式 `→ +50修为 +20灵石` 只包含 exp/gold/loot，**缺少**：
+- HP 变化（`result.playerHpLeft` vs `maxHp`）
+- MP 消耗（`result.mpUsed`）
+- 健康/心情变化（战败时扣减的 health）
+
+同时 `advanceTime()` 在 `fight()` 内调用，可能触发日常事件产生额外日志条目，加上 Toast 放大散乱感。
+
+---
+
+## 数据结构
+
+### 无需新增类型
+
+现有 `ToastMessage`、`LogEntry`、`CombatResult` 类型足够，方案主要是行为调整。
+
+### 可选：给 addLog 增加 `silent` 参数
+
+```ts
+// addLog 签名（可选扩展）
+addLog(msg: string, category?: LogCategory, options?: { silent?: boolean })
+```
+
+`silent: true` 时只写日志不弹 Toast。大部分战斗/日常/探索日志用 silent 模式，仅关键事件弹 Toast。
+
+---
+
+## 游戏逻辑方案（@Dev）
+
+### 方案 A：Toast 改为"最新消息条"（推荐）
+
+将屏幕顶部堆叠的多条 Toast 气泡，替换为**单条消息栏**：
+
+- 只显示**最新一条**消息，不叠加
+- 位置改为中央面板顶部（或日志面板上方），而非 fixed 浮层
+- 3 秒后自动淡出，新消息进来立即替换旧消息
+- 视觉风格：半透明细条，字体更小，不抢注意力
+- 保留类别颜色左边框
+
+### 方案 B：分级 Toast + 关键事件才弹（备选）
+
+给 `addLog` 增加 `toast` 选项，只有显式传 `toast: true` 的才弹气泡：
+- **弹 Toast**：突破成功/失败、战斗胜利/死亡、奇遇触发、⚠️ 警告
+- **不弹 Toast**：修炼、休息、探索拾取、日常事件、炼丹/锻造结果、商店交易
+
+**推荐方案 A**，因为改动最小且彻底解决堆叠问题。
+
+### 修改文件
+
+| 文件 | 改动 | 原因 |
+|------|------|------|
+| `src/hooks/useToast.ts` | 改为只维护单条消息（移除数组/MAX_TOASTS），新消息替换旧消息 | 核心机制简化 |
+| `src/components/hud/ToastContainer.tsx` | 从多条 `.map()` 改为单条渲染，样式改为内联消息条 | UI 降噪 |
+| `src/App.css` | `.toast-container` / `.toast-item` 样式调整：去掉 `position: fixed; top: 2rem`，改为 `position: relative` 嵌入布局流；减小 padding/font-size；简化动画 | 降低视觉侵入 |
+| `src/hooks/useGameEngine.ts` | `handleCombatClose` 中战斗日志格式改为括号摘要；`addLog` / `addLogs` 的 Toast 调用逻辑精简 | 合并战斗摘要 |
+| `src/hooks/useCoreActions.ts` | `explore` 拾取日志合并到探索消息中（不再单独一条） | 减少日志条数 |
+| `src/App.tsx` | `<ToastContainer>` 位置可能从 fixed 层移入中央面板内 | 布局调整 |
+
+### 战斗日志合并格式
+
+**胜利**：
+```
+⚔️ 击败 炎蛇（+50修为 +20灵石 -30HP -15MP 获得: 妖兽獠牙×1）
+```
+
+**失败**：
+```
+💀 败于 炎蛇（-80HP -20健康 护命玉佩救回一命）
+```
+或
+```
+💀 败于 炎蛇（-80HP -20健康 损失50修为 掉落灵石30）
+```
+
+**超时**：
+```
+⚔️ 与 炎蛇 缠斗超时，双方脱战（-40HP -10MP）
+```
+
+#### 格式规则
+
+- 主体 `emoji + 结果描述`，然后用括号 `（…）` 包裹所有数值变化
+- 括号内各项用空格分隔
+- 正数用 `+`，负数用 `-`
+- 物品掉落用 `获得: xxx×n`
+- 整条是一个 `addLog` 调用
+
+### 探索日志合并
+
+当前探索拾取物品会单独一条日志：
+```
+🔍 山中发现灵药！
+🎁 拾取 灵芝 ×1
+```
+
+合并为：
+```
+🔍 山中发现灵药！（获得灵芝×1）
+```
+
+### 公式
+
+无新增公式。战斗摘要需在 `handleCombatClose` 中计算：
+- `hpDelta = result.playerHpLeft - player.maxHp`（负值）→ 实际应基于战斗前 HP，但当前没有存战斗前快照。简化方案：只展示 `result.hpLost`（如 CombatResult 有），或展示战后 HP 值
+- `mpUsed = result.mpUsed`
+- `expGained = result.expGained`
+- `goldGained = result.goldGained`
+
+如果 CombatResult 中没有 `hpLost` 字段，可以从 `result.playerHpLeft` 和 `result.rounds` 推算，或在 `fight()` 中将战斗前的 HP 快照存入 CombatModalState。
+
+---
+
+## UI 方案（@Designer）
+
+### Toast 消息条（替换原 Toast 气泡）
+
+| 元素 | 位置 | 内容 |
+|------|------|------|
+| 消息条 `.toast-bar` | 中央面板顶部，在日志面板上方 | 单条最新消息，左侧类别色条，3s 淡出 |
+
+### 样式要点
+
+- **不使用 `position: fixed`**，嵌入正常布局流
+- 高度 `~28px`，`font-size: 0.75rem`，`padding: 4px 10px`
+- 背景 `rgba(18, 22, 42, 0.7)`，比原 Toast 更透明
+- 淡入淡出动画保持 0.3s
+- 空消息时不占位（`display: none` 或不渲染）
+
+### 战斗日志
+
+- 括号内容用略小/略灰的字号区分主体与详情（可选，通过 CSS `span.log-detail` 控制）
+- 日志面板中的展示不变，仍按时间线分组
+
+### 交互
+
+- 消息条点击后立即消失（保留 dismiss 功能）
+- 无其他新交互
+
+---
+
+## 验证方式
+
+1. **Toast 降噪**
+   - 连续快速点击「修炼」5 次，观察屏幕顶部：应只显示一条消息，不叠加
+   - 同时有日常事件触发时，新消息替换旧消息而非堆叠
+   - 消息 3s 后自动淡出
+
+2. **战斗日志合并**
+   - 战斗胜利后关闭弹窗，日志面板应只新增一条包含 `（+修为 +灵石 -HP …）` 的摘要
+   - 战斗失败有死亡系统处理时，日志也应为一条（括号内含惩罚信息）
+   - 探索拾取物品时，日志为一条（事件描述 + 括号内获得物品）
+
+3. **边界条件**
+   - 战斗无掉落时，括号内只有 `+修为 +灵石`
+   - ⚠️ 提示（精力不足等）仍正常显示在消息条
+   - 清空日志后，消息条也应清空
+
+4. **Debug 辅助验证**
+   - 在 Debug 面板将精力设为 0，检查 ⚠️ 提示是否正常显示
+   - 手动触发战斗，检查日志格式
+
+## 调试面板需求
+
+无需更新。现有 Debug 面板可修改精力/HP 等属性辅助测试。
+
+## 依赖关系
+
+- **前置任务**：T0043 ✅（日志系统改进）、T0044 ✅（战斗弹窗 + 日志精简）
+- **后续任务**：无

--- a/docs/tasks/done/T0040-death-system.md
+++ b/docs/tasks/done/T0040-death-system.md
@@ -1,9 +1,10 @@
 # T0040 — 死亡与复活系统
 
-- **状态**: ⬜ 未开始
+- **状态**: ✅ 已完成（2026-03-30）
 - **分类**: 进阶机制
 - **前置**: T0001, T0003, T0012, T0018, T0044
 - **Spec**: [docs/specs/T0040-death-system.md](../specs/T0040-death-system.md)
+- **关键文件**: `src/game/death.ts`、`src/game/events.ts`、`src/components/shared/DeathModal.tsx`、`src/hooks/useCoreActions.ts`、`src/hooks/useGameEngine.ts`
 
 ## 描述
 

--- a/docs/tasks/done/T0045-toast-combat-log-polish.md
+++ b/docs/tasks/done/T0045-toast-combat-log-polish.md
@@ -1,0 +1,32 @@
+# T0045 — Toast 降噪 + 战斗日志合并
+
+**类型**：feat（UI 体验优化）
+**状态**：✅ 已完成（2026-03-30）
+**前置**：T0043 ✅, T0044 ✅
+**设计文档**：[spec](../../specs/T0045-toast-combat-log-polish.md)
+**关键文件**：`src/hooks/useToast.ts`、`src/components/hud/ToastContainer.tsx`、`src/components/shared/CombatModal.tsx`、`src/hooks/useGameEngine.ts`、`src/hooks/useCoreActions.ts`、`src/components/layout/GameLayout.tsx`
+
+## 目标
+
+1. 将 Toast 从多条堆叠气泡改为单条消息栏，降低视觉噪音
+2. 战斗日志合并为一条结构化摘要，括号内包含所有属性变化
+3. 探索拾取日志合并到探索事件描述中
+
+## 关键改动
+
+| 文件 | 改动 |
+|------|------|
+| `src/hooks/useToast.ts` | 单条消息机制，新消息替换旧消息 |
+| `src/components/hud/ToastContainer.tsx` | 单条渲染，降低视觉强度 |
+| `src/App.css` | 样式从 fixed 浮层改为内联消息条 |
+| `src/hooks/useGameEngine.ts` | `handleCombatClose` 战斗摘要格式 |
+| `src/hooks/useCoreActions.ts` | 探索日志合并 |
+| `src/App.tsx` | ToastContainer 位置调整 |
+
+## 完成标准
+
+- [ ] Toast 改为单条消息栏，不再堆叠
+- [ ] 战斗胜利日志格式：`⚔️ 击败 X（+修为 +灵石 -HP 获得: Y×n）`
+- [ ] 战斗失败日志格式：`💀 败于 X（-HP -健康 惩罚信息）`
+- [ ] 探索拾取合并为一条
+- [ ] ⚠️ 提示正常工作

--- a/src/App.css
+++ b/src/App.css
@@ -677,55 +677,54 @@ body {
   50% { box-shadow: 0 0 12px rgba(255, 215, 0, 0.6); }
 }
 
-/* ── Toast 即时反馈 ── */
-.toast-container {
-  position: fixed;
-  top: 2rem;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1000;
+/* ── Toast 消息栏（顶部固定占位） ── */
+.top-message-bar {
+  width: 100%;
+  min-height: 28px;
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  pointer-events: none;
-  max-width: 500px;
-  width: 90%;
+  align-items: center;
+  justify-content: center;
 }
 
-.toast-item {
-  background: rgba(18, 22, 42, 0.95);
+.toast-bar {
+  background: rgba(18, 22, 42, 0.85);
   border: 1px solid #2a2e3e;
   border-left: 3px solid #aaa;
-  border-radius: 6px;
-  padding: 0.5rem 0.8rem;
-  font-size: 0.82rem;
+  border-radius: 4px;
+  padding: 4px 16px;
+  font-size: 0.78rem;
   color: #ddd;
-  pointer-events: auto;
   cursor: pointer;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
-  animation: toastIn 0.3s ease-out;
+  width: 100%;
+  text-align: center;
+  transition: opacity 0.3s ease;
 }
 
-.toast-item:hover {
-  background: rgba(26, 30, 46, 0.98);
+.toast-bar:hover {
+  background: rgba(26, 30, 46, 0.95);
 }
 
 .toast-fade-in {
-  animation: toastIn 0.3s ease-out;
+  animation: toastFadeIn 0.3s ease-out;
 }
 
 .toast-fade-out {
-  animation: toastOut 0.3s ease-in forwards;
+  animation: toastFadeOut 0.3s ease-in forwards;
 }
 
-@keyframes toastIn {
-  from { opacity: 0; transform: translateY(-12px); }
-  to   { opacity: 1; transform: translateY(0); }
+.top-message-bar:empty,
+.top-message-bar:not(:has(.toast-bar)) {
+  min-height: 28px;
 }
 
-@keyframes toastOut {
-  from { opacity: 1; transform: translateY(0); }
-  to   { opacity: 0; transform: translateY(-12px); }
+@keyframes toastFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes toastFadeOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
 }
 
 /* ── 日志面板（时间线） ── */
@@ -1812,10 +1811,60 @@ body {
 }
 
 .combat-modal-log-line {
-  padding: 0.2rem 0;
+  padding: 0.15rem 0;
   font-size: 0.85rem;
-  color: #ef5350;
+  color: #bbb;
   line-height: 1.5;
+}
+
+/* 战斗日志富文本着色 */
+.cl-text     { color: #bbb; }
+.cl-player   { color: #5bc0de; font-weight: bold; }
+.cl-monster  { color: #e67e22; font-weight: bold; }
+.cl-skill    { color: #d4a843; font-weight: bold; }
+.cl-damage   { color: #ef5350; font-weight: bold; }
+.cl-heal     { color: #66bb6a; font-weight: bold; }
+.cl-crit     { color: #ff7043; font-weight: bold; text-shadow: 0 0 4px rgba(255, 112, 67, 0.5); }
+.cl-dodge    { color: #78909c; font-style: italic; }
+.cl-info     { color: #d4a843; }
+.cl-mp       { color: #7e57c2; }
+.cl-debuff   { color: #ab47bc; }
+
+.combat-modal-fixed {
+  height: 70vh;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.combat-modal-fixed .combat-modal-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.combat-round-block {
+  margin-bottom: 0.6rem;
+  padding: 0.4rem 0.6rem;
+  background: rgba(255, 255, 255, 0.02);
+  border-left: 2px solid #333;
+  border-radius: 0 4px 4px 0;
+}
+
+.combat-round-header {
+  color: #d4a843;
+  font-size: 0.8rem;
+  font-weight: bold;
+  padding: 0.15rem 0;
+  margin-bottom: 0.2rem;
+}
+
+.combat-log-appear {
+  animation: logAppear 0.3s ease-out;
+}
+
+@keyframes logAppear {
+  from { opacity: 0; transform: translateX(-8px); }
+  to   { opacity: 1; transform: translateX(0); }
 }
 
 .combat-modal-footer {
@@ -1894,22 +1943,28 @@ body {
   margin-left: auto;
 }
 
-.log-collapse-btn {
-  background: none;
-  border: 1px solid #333;
-  border-radius: 4px;
-  color: #888;
+.log-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid #3a3e52;
+  border-radius: 50%;
+  color: #d4a843;
   cursor: pointer;
-  padding: 0.15rem 0.35rem;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   line-height: 1;
-  transition: all 0.15s;
+  margin-left: 6px;
+  vertical-align: middle;
+  transition: all 0.2s;
 }
 
-.log-collapse-btn:hover {
-  background: #1e2235;
-  color: #ccc;
-  border-color: #555;
+.log-toggle-btn:hover {
+  background: rgba(212, 168, 67, 0.15);
+  border-color: #d4a843;
+  color: #f0c96a;
 }
 
 /* ── T0040: DeathModal 死亡弹窗 ── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ export default function App() {
 
   return (
     <GameLayout
+      topBar={<ToastContainer toast={engine.toast} onDismiss={engine.dismissToast} />}
       left={
         <LeftPanel
           player={engine.player}
@@ -93,7 +94,6 @@ export default function App() {
       }
       debug={<>
         <DebugPanel player={engine.player} onUpdate={engine.debugSetPlayer} />
-        <ToastContainer toasts={engine.toasts} onDismiss={engine.dismissToast} />
         {engine.combatModal && (
           <CombatModal
             state={engine.combatModal}

--- a/src/components/hud/GameLog.tsx
+++ b/src/components/hud/GameLog.tsx
@@ -53,11 +53,7 @@ export default function GameLog({ logs, currentYear = 1, currentMonth = 1 }: Gam
     });
   };
 
-  // 折叠全部 / 展开全部
-  const collapseAll = () => {
-    setExpandedYears(new Set());
-    setExpandedMonths(new Set());
-  };
+  const [allExpanded, setAllExpanded] = useState(false);
 
   const expandAll = () => {
     const allYears = new Set(grouped.keys());
@@ -69,6 +65,17 @@ export default function GameLog({ logs, currentYear = 1, currentMonth = 1 }: Gam
     }
     setExpandedYears(allYears);
     setExpandedMonths(allMonths);
+    setAllExpanded(true);
+  };
+
+  const collapseAll = () => {
+    setExpandedYears(new Set());
+    setExpandedMonths(new Set());
+    setAllExpanded(false);
+  };
+
+  const toggleAll = () => {
+    if (allExpanded) collapseAll(); else expandAll();
   };
 
   // 按年降序排列
@@ -77,7 +84,7 @@ export default function GameLog({ logs, currentYear = 1, currentMonth = 1 }: Gam
   return (
     <div className="game-log">
       <div className="log-header">
-        <h3>📜 日志</h3>
+        <h3>📜 日志 <button className="log-toggle-btn" onClick={toggleAll} title={allExpanded ? '折叠全部' : '展开全部'}>{allExpanded ? '▾' : '▸'}</button></h3>
         <TabBar
           tabs={FILTER_TABS}
           activeKey={filter}
@@ -85,10 +92,6 @@ export default function GameLog({ logs, currentYear = 1, currentMonth = 1 }: Gam
           className="log-filters"
           tabClassName="log-filter-btn"
         />
-        <div className="log-header-actions">
-          <button className="log-collapse-btn" onClick={expandAll} title="展开全部">🔽</button>
-          <button className="log-collapse-btn" onClick={collapseAll} title="折叠全部">🔼</button>
-        </div>
       </div>
       <div className="log-list">
         {years.length === 0 && <p className="log-empty">暂无日志…</p>}

--- a/src/components/hud/ToastContainer.tsx
+++ b/src/components/hud/ToastContainer.tsx
@@ -1,30 +1,25 @@
 // ============================================================
-// hud/ToastContainer.tsx — Toast 气泡容器
+// hud/ToastContainer.tsx — 单条消息条（替代多条 Toast 气泡）
 // ============================================================
 
 import type { ToastMessage } from '../../hooks/useToast';
 import { LOG_COLORS } from '../../hooks/useGameLog';
 
-interface ToastContainerProps {
-  toasts: ToastMessage[];
-  onDismiss: (id: number) => void;
+interface ToastBarProps {
+  toast: ToastMessage | null;
+  onDismiss: () => void;
 }
 
-export default function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
-  if (toasts.length === 0) return null;
+export default function ToastContainer({ toast, onDismiss }: ToastBarProps) {
+  if (!toast) return null;
 
   return (
-    <div className="toast-container">
-      {toasts.map(toast => (
-        <div
-          key={toast.id}
-          className={`toast-item ${toast.fading ? 'toast-fade-out' : 'toast-fade-in'}`}
-          style={{ borderLeftColor: LOG_COLORS[toast.category] || LOG_COLORS.default }}
-          onClick={() => onDismiss(toast.id)}
-        >
-          {toast.text}
-        </div>
-      ))}
+    <div
+      className={`toast-bar ${toast.fading ? 'toast-fade-out' : 'toast-fade-in'}`}
+      style={{ borderLeftColor: LOG_COLORS[toast.category] || LOG_COLORS.default }}
+      onClick={onDismiss}
+    >
+      {toast.text}
     </div>
   );
 }

--- a/src/components/layout/GameLayout.tsx
+++ b/src/components/layout/GameLayout.tsx
@@ -9,12 +9,14 @@ interface GameLayoutProps {
   left: ReactNode;
   center: ReactNode;
   right: ReactNode;
+  topBar?: ReactNode;
   debug?: ReactNode;
 }
 
-export default function GameLayout({ left, center, right, debug }: GameLayoutProps) {
+export default function GameLayout({ left, center, right, topBar, debug }: GameLayoutProps) {
   return (
     <div className="game-layout-wrapper">
+      {topBar && <div className="top-message-bar">{topBar}</div>}
       <div className="game-layout">
         <aside className="left-panel">{left}</aside>
         <main className="center-panel">{center}</main>

--- a/src/components/shared/CombatModal.tsx
+++ b/src/components/shared/CombatModal.tsx
@@ -1,8 +1,9 @@
 // ============================================================
 // CombatModal.tsx — 两阶段战斗结果弹窗（T0044）
-// Phase 1: 回合日志 → Phase 2: 战利品展示
+// Phase 1: 按回合逐组显示 → Phase 2: 战利品展示
 // ============================================================
 
+import { useState, useEffect, useRef, useMemo, type ReactNode } from 'react';
 import type { CombatModalState } from '../../hooks/useGameEngine';
 
 interface CombatModalProps {
@@ -11,21 +12,142 @@ interface CombatModalProps {
   onClose: () => void;  // 关闭弹窗
 }
 
+/** 将日志按回合分组：以 "── 第 X 回合 ──" 为分界线 */
+function groupByRound(logs: string[]): string[][] {
+  const groups: string[][] = [];
+  let current: string[] = [];
+  for (const line of logs) {
+    if (/^── 第 \d+ 回合 ──$/.test(line)) {
+      if (current.length > 0) groups.push(current);
+      current = [line];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
+/** 富文本渲染：给日志中的关键词上色 */
+function renderLogLine(line: string, monsterName: string): ReactNode {
+  // 数字（伤害/恢复量）高亮
+  // 玩家名"你"用蓝绿色，怪物名用橙红色
+  // 技能名【xxx】用金色
+  const parts: ReactNode[] = [];
+  // 用正则拆分出需要高亮的部分
+  const regex = /(你|【[^】]+】|\d+ 点伤害|\d+ 点生命|暴击|闪避|先手|击败|灵力-\d+)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  const escaped = monsterName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const fullRegex = new RegExp(`(${escaped}|你|【[^】]+】|\\d+ 点伤害|\\d+ 点生命|暴击！|闪避|先手|击败|灵力-\\d+|防御降低 \\d+|攻击降低 \\d+|灼烧伤害 \\d+)`, 'g');
+
+  while ((match = fullRegex.exec(line)) !== null) {
+    // text before match
+    if (match.index > lastIndex) {
+      parts.push(<span key={`t${lastIndex}`} className="cl-text">{line.slice(lastIndex, match.index)}</span>);
+    }
+    const word = match[1];
+    let cls = 'cl-text';
+    if (word === '你') {
+      cls = 'cl-player';
+    } else if (word === monsterName) {
+      cls = 'cl-monster';
+    } else if (word.startsWith('【')) {
+      cls = 'cl-skill';
+    } else if (/\d+ 点伤害/.test(word)) {
+      cls = 'cl-damage';
+    } else if (/\d+ 点生命/.test(word)) {
+      cls = 'cl-heal';
+    } else if (word === '暴击！') {
+      cls = 'cl-crit';
+    } else if (word === '闪避') {
+      cls = 'cl-dodge';
+    } else if (word === '先手' || word === '击败') {
+      cls = 'cl-info';
+    } else if (/灵力-\d+/.test(word)) {
+      cls = 'cl-mp';
+    } else if (/防御降低|攻击降低|灼烧伤害/.test(word)) {
+      cls = 'cl-debuff';
+    }
+    parts.push(<span key={`m${match.index}`} className={cls}>{word}</span>);
+    lastIndex = match.index + word.length;
+  }
+  if (lastIndex < line.length) {
+    parts.push(<span key={`e${lastIndex}`} className="cl-text">{line.slice(lastIndex)}</span>);
+  }
+  return parts.length > 0 ? <>{parts}</> : line;
+}
+
+const ROUND_INTERVAL = 800; // 每回合间隔 ms
+
 export default function CombatModal({ state, onNext, onClose }: CombatModalProps) {
   const { phase, monsterName, result, loot } = state;
+  const rounds = useMemo(() => groupByRound(result.logs), [result.logs]);
+  const [visibleRounds, setVisibleRounds] = useState(0);
+  const [allRevealed, setAllRevealed] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // 逐回合显示
+  useEffect(() => {
+    if (phase !== 'battle') return;
+    setVisibleRounds(0);
+    setAllRevealed(false);
+
+    let count = 0;
+    timerRef.current = window.setInterval(() => {
+      count++;
+      setVisibleRounds(count);
+      if (count >= rounds.length) {
+        if (timerRef.current) clearInterval(timerRef.current);
+        timerRef.current = null;
+        setAllRevealed(true);
+      }
+    }, ROUND_INTERVAL);
+
+    return () => {
+      if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+    };
+  }, [phase, rounds.length]);
+
+  // 自动滚动到最新回合
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [visibleRounds]);
+
+  // 跳过动画
+  const skipAnimation = () => {
+    if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+    setVisibleRounds(rounds.length);
+    setAllRevealed(true);
+  };
 
   if (phase === 'battle') {
     return (
       <div className="combat-modal-overlay">
-        <div className="combat-modal">
+        <div className="combat-modal combat-modal-fixed">
           <div className="combat-modal-header">⚔️ 战斗 — {monsterName}</div>
-          <div className="combat-modal-body">
-            {result.logs.map((log, i) => (
-              <div key={i} className="combat-modal-log-line">{log}</div>
+          <div className="combat-modal-body" ref={scrollRef}>
+            {rounds.slice(0, visibleRounds).map((group, gi) => (
+              <div key={gi} className="combat-round-block combat-log-appear">
+                {group.map((line, li) => {
+                  const isRoundHeader = /^── 第 \d+ 回合 ──$/.test(line);
+                  return (
+                    <div key={li} className={isRoundHeader ? 'combat-round-header' : 'combat-modal-log-line'}>
+                      {isRoundHeader ? line : renderLogLine(line, monsterName)}
+                    </div>
+                  );
+                })}
+              </div>
             ))}
           </div>
           <div className="combat-modal-footer">
-            {result.winner === 'monster' ? (
+            {!allRevealed ? (
+              <button className="btn combat-modal-btn" onClick={skipAnimation}>跳过 ▶▶</button>
+            ) : result.winner === 'monster' ? (
               <button className="btn combat-modal-btn" onClick={onClose}>确认</button>
             ) : (
               <button className="btn combat-modal-btn" onClick={onNext}>查看战利品 ▶</button>

--- a/src/hooks/useCoreActions.ts
+++ b/src/hooks/useCoreActions.ts
@@ -38,7 +38,7 @@ export interface CoreActionDeps {
   setPlayer: React.Dispatch<React.SetStateAction<Player | null>>;
   advanceTime: (p: Player, actionKey: string) => Player;
   canAct: (actionKey: string) => boolean;
-  onCombatResult: (monsterName: string, result: CombatResult, loot: LootEntry[], deathInfo?: CombatDeathInfo) => void;
+  onCombatResult: (monsterName: string, result: CombatResult, loot: LootEntry[], deathInfo?: CombatDeathInfo, hpBefore?: number, mpBefore?: number) => void;
 }
 
 export function useCoreActions(deps: CoreActionDeps) {
@@ -46,7 +46,7 @@ export function useCoreActions(deps: CoreActionDeps) {
   // 收集日志用 ref，避免 React strict mode 重复
   const pendingRef = useRef<{ msgs: string[]; categories: LogCategory[] }>({ msgs: [], categories: [] });
   // 战斗结果暂存（setPlayer回调内收集，setTimeout中消费）
-  const combatResultRef = useRef<{ monsterName: string; result: CombatResult; loot: LootEntry[]; deathInfo?: CombatDeathInfo } | null>(null);
+  const combatResultRef = useRef<{ monsterName: string; result: CombatResult; loot: LootEntry[]; deathInfo?: CombatDeathInfo; hpBefore: number; mpBefore: number } | null>(null);
 
   const flushLogs = () => {
     const { msgs, categories } = pendingRef.current;
@@ -124,6 +124,10 @@ export function useCoreActions(deps: CoreActionDeps) {
       // 收集战利品用于弹窗展示
       const loot: LootEntry[] = [];
 
+      // 记录战斗前 HP/MP 用于日志摘要
+      const hpBefore = p.hp;
+      const mpBefore = p.mp;
+
       p.hp = result.playerHpLeft;
       p.exp += result.expGained;
       p.gold += result.goldGained;
@@ -173,17 +177,16 @@ export function useCoreActions(deps: CoreActionDeps) {
           data: { monsterRealmIndex: monster.realmIndex, isBoss },
         });
 
+        let localDeathInfo: CombatDeathInfo | undefined;
+
         if (deathCheck.triggered) {
           if (deathCheck.blocked) {
             // 护命道具拦截
             p = deathCheck.player;
-            combatResultRef.current = {
-              monsterName: monster.name, result, loot,
-              deathInfo: {
-                blocked: true,
-                saverName: deathCheck.blockedBy?.name,
-                triggered: true,
-              },
+            localDeathInfo = {
+              blocked: true,
+              saverName: deathCheck.blockedBy?.name,
+              triggered: true,
             };
           } else {
             // 死亡触发
@@ -193,39 +196,38 @@ export function useCoreActions(deps: CoreActionDeps) {
             if (death.severity !== 'severe') {
               p.hp = Math.max(1, Math.floor(p.maxHp * 0.1));
             }
-            combatResultRef.current = {
-              monsterName: monster.name, result, loot,
-              deathInfo: {
-                blocked: false,
-                triggered: true,
-                severity: death.severity,
-                penaltyLogs: death.logs,
-                availableRevivals: death.availableRevivals,
-                triggerDef: deathCheck.trigger!,
-              },
+            localDeathInfo = {
+              blocked: false,
+              triggered: true,
+              severity: death.severity,
+              penaltyLogs: death.logs,
+              availableRevivals: death.availableRevivals,
+              triggerDef: deathCheck.trigger!,
             };
           }
         } else {
           // 兜底：未触发死亡（理论上不会到这）
           p.health = Math.max(0, p.health - 20);
           p.hp = Math.max(1, Math.floor(p.maxHp * 0.1));
-          combatResultRef.current = { monsterName: monster.name, result, loot };
         }
         if (p.hp < p.maxHp * 0.1) {
           p.tracking = { ...p.tracking, hasBeenBelow10Hp: true };
         }
+        combatResultRef.current = { monsterName: monster.name, result, loot, deathInfo: localDeathInfo, hpBefore, mpBefore };
       }
 
-      // 暂存战斗结果，不写日志
-      combatResultRef.current = { monsterName: monster.name, result, loot };
+      // 暂存战斗结果（玩家胜利 / 平局时 deathInfo 为空）
+      if (!combatResultRef.current) {
+        combatResultRef.current = { monsterName: monster.name, result, loot, hpBefore, mpBefore };
+      }
 
       p = advanceTime(p, 'combat');
       return p;
     });
     setTimeout(() => {
       if (combatResultRef.current) {
-        const { monsterName, result, loot, deathInfo } = combatResultRef.current;
-        onCombatResult(monsterName, result, loot, deathInfo);
+        const { monsterName, result, loot, deathInfo, hpBefore, mpBefore } = combatResultRef.current;
+        onCombatResult(monsterName, result, loot, deathInfo, hpBefore, mpBefore);
         combatResultRef.current = null;
       } else {
         flushLogs();
@@ -251,7 +253,7 @@ export function useCoreActions(deps: CoreActionDeps) {
       p = { ...updated };
 
       pendingRef.current = { msgs: [], categories: [] };
-      queueLog(message, message.includes('【奇遇】') ? 'adventure' : 'explore');
+      let exploreMsg = message;
 
       const exploreLoot: [string, number][] = [
         ['core:iron_ore', 0.15],
@@ -269,11 +271,13 @@ export function useCoreActions(deps: CoreActionDeps) {
           if (added > 0) {
             p = p2;
             const def = getItemDef(itemId);
-            queueLog(`🎁 拾取 ${def?.name ?? itemId} ×1`, 'explore');
+            exploreMsg += `（获得${def?.name ?? itemId}×1）`;
           }
           break;
         }
       }
+
+      queueLog(exploreMsg, exploreMsg.includes('【奇遇】') ? 'adventure' : 'explore');
 
       p = advanceTime(p, 'explore');
       return p;

--- a/src/hooks/useGameEngine.ts
+++ b/src/hooks/useGameEngine.ts
@@ -27,6 +27,8 @@ export interface CombatModalState {
   result: CombatResult;
   loot: LootEntry[];
   deathInfo?: CombatDeathInfo;
+  playerHpBefore: number;
+  playerMpBefore: number;
 }
 
 export interface DeathModalState {
@@ -85,7 +87,7 @@ export function useGameEngine(
   const [combatModal, setCombatModal] = useState<CombatModalState | null>(null);
   const [deathModal, setDeathModal] = useState<DeathModalState | null>(null);
   const playerRef = useRef<Player | null>(null);
-  const { toasts, showToast, dismiss: dismissToast } = useToast();
+  const { toast, showToast, dismiss: dismissToast } = useToast();
 
   // 同步 playerRef
   useEffect(() => { playerRef.current = player; }, [player]);
@@ -271,8 +273,8 @@ export function useGameEngine(
   }, [player, gameOver]);
 
   // ── 战斗弹窗回调（T0044 + T0040）──
-  const onCombatResult = useCallback((monsterName: string, result: CombatResult, loot: LootEntry[], deathInfo?: CombatDeathInfo) => {
-    setCombatModal({ phase: 'battle', monsterName, result, loot, deathInfo });
+  const onCombatResult = useCallback((monsterName: string, result: CombatResult, loot: LootEntry[], deathInfo?: CombatDeathInfo, hpBefore?: number, mpBefore?: number) => {
+    setCombatModal({ phase: 'battle', monsterName, result, loot, deathInfo, playerHpBefore: hpBefore ?? 0, playerMpBefore: mpBefore ?? 0 });
   }, []);
 
   const handleCombatNext = useCallback(() => {
@@ -285,22 +287,36 @@ export function useGameEngine(
   const handleCombatClose = useCallback(() => {
     const modal = combatModalRef.current;
     if (!modal) return;
-    const { monsterName, result, loot, deathInfo } = modal;
+    const { monsterName, result, loot, deathInfo, playerHpBefore, playerMpBefore } = modal;
+
     if (result.winner === 'player') {
-      const parts = [`⚔️ 击败 ${monsterName} → +${result.expGained}修为 +${result.goldGained}灵石`];
-      for (const l of loot) parts.push(`${l.name}×${l.amount}`);
-      addLog(parts.join(' '), 'combat');
+      const details: string[] = [];
+      if (result.expGained > 0) details.push(`+${result.expGained}修为`);
+      if (result.goldGained > 0) details.push(`+${result.goldGained}灵石`);
+      const hpLost = playerHpBefore - result.playerHpLeft;
+      if (hpLost > 0) details.push(`-${hpLost}HP`);
+      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
+      if (loot.length > 0) details.push(`获得: ${loot.map(l => `${l.name}×${l.amount}`).join(' ')}`);
+      addLog(`⚔️ 击败 ${monsterName}（${details.join(' ')}）`, 'combat');
     } else if (result.winner === 'monster') {
+      const details: string[] = [];
+      const hpLost = playerHpBefore - result.playerHpLeft;
+      if (hpLost > 0) details.push(`-${hpLost}HP`);
+      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
       if (deathInfo?.blocked) {
-        addLog(`⚔️ 败于 ${monsterName}，${deathInfo.saverName}抵消了致命伤害！`, 'combat');
-      } else if (deathInfo?.triggered && deathInfo.severity && deathInfo.severity !== 'severe') {
-        const penaltyMsg = deathInfo.penaltyLogs?.join('，') || '';
-        addLog(`💀 败于 ${monsterName}，${penaltyMsg}`, 'combat');
+        details.push(`${deathInfo.saverName ?? '护命道具'}救回一命`);
+      } else if (deathInfo?.triggered && deathInfo.penaltyLogs?.length) {
+        details.push(...deathInfo.penaltyLogs);
       } else {
-        addLog(`💀 败于 ${monsterName}，身受重伤`, 'combat');
+        details.push('-20健康');
       }
+      addLog(`💀 败于 ${monsterName}（${details.join(' ')}）`, 'combat');
     } else {
-      addLog(`⚔️ 与 ${monsterName} 战斗超时，双方脱战`, 'combat');
+      const details: string[] = [];
+      const hpLost = playerHpBefore - result.playerHpLeft;
+      if (hpLost > 0) details.push(`-${hpLost}HP`);
+      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
+      addLog(`⚔️ 与 ${monsterName} 缠斗超时，双方脱战（${details.join(' ')}）`, 'combat');
     }
     setCombatModal(null);
 
@@ -390,7 +406,7 @@ export function useGameEngine(
     learnTechnique,
     practiceTechnique,
     activateTechnique,
-    toasts,
+    toast,
     dismissToast,
     combatModal,
     handleCombatNext,

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,5 +1,5 @@
 // ============================================================
-// hooks/useToast.ts — Toast 即时反馈管理
+// hooks/useToast.ts — Toast 消息条（单条最新消息，3s 淡出）
 // ============================================================
 
 import { useState, useCallback, useRef } from 'react';
@@ -12,30 +12,24 @@ export interface ToastMessage {
   fading?: boolean;
 }
 
-const MAX_TOASTS = 5;
 const DEFAULT_DURATION = 3000;
 
 export function useToast() {
-  const [toasts, setToasts] = useState<ToastMessage[]>([]);
-  const timersRef = useRef<Map<number, number>>(new Map());
+  const [toast, setToast] = useState<ToastMessage | null>(null);
+  const timerRef = useRef<number | null>(null);
 
-  const dismiss = useCallback((id: number) => {
-    // 先标记 fading 触发退出动画
-    setToasts(prev => prev.map(t => t.id === id ? { ...t, fading: true } : t));
-    setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id));
-    }, 300);
-    const timer = timersRef.current.get(id);
-    if (timer) { clearTimeout(timer); timersRef.current.delete(id); }
+  const dismiss = useCallback(() => {
+    setToast(prev => prev ? { ...prev, fading: true } : null);
+    setTimeout(() => setToast(null), 300);
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
   }, []);
 
   const showToast = useCallback((text: string, category: LogCategory = 'default', duration = DEFAULT_DURATION) => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
     const id = Date.now() + Math.random();
-    const toast: ToastMessage = { id, text, category };
-    setToasts(prev => [...prev, toast].slice(-MAX_TOASTS));
-    const timer = window.setTimeout(() => dismiss(id), duration);
-    timersRef.current.set(id, timer);
+    setToast({ id, text, category, fading: false });
+    timerRef.current = window.setTimeout(() => dismiss(), duration);
   }, [dismiss]);
 
-  return { toasts, showToast, dismiss };
+  return { toast, showToast, dismiss };
 }


### PR DESCRIPTION
## T0040 死亡系统
- 文档同步更新（task → done/）

## T0045 Toast降噪 + 战斗日志合并
- Toast 改为顶部固定消息栏
- 战斗/探索日志合并为单行摘要
- 战斗弹窗按回合逐组显示（800ms间隔）
- 日志富文本着色（玩家/怪物/伤害/技能等分色）
- 折叠按钮改为紧凑单按钮（▸/▾）

## 文档同步
T0040/T0045 → done/, roadmap + progress 已更新