### PR TITLE
fix: 浮动面板互斥 — 详细属性与右侧面板共享同一状态

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,8 @@ export default function App() {
       left={
         <LeftPanel
           player={engine.player}
+          activePanel={activePanel}
+          onSelectPanel={handleSelectPanel}
         />
       }
       center={

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -2,20 +2,21 @@
 // layout/LeftPanel.tsx — 左栏：头像 + 道号 + 境界 + 核心属性
 // ============================================================
 
-import { useState } from 'react';
 import type { Player } from '../../game/player';
 import { REALMS, MONTH_NAMES } from '../../game/data';
 import { getNextRealm } from '../../game/player';
 import Avatar from './Avatar';
 import { CapacityBar, FloatingPanel, STAT_COLORS } from '../shared';
 import StatusPanel from '../panels/StatusPanel';
+import type { PanelKey } from './PanelButtons';
 
 interface LeftPanelProps {
   player: Player;
+  activePanel: PanelKey | null;
+  onSelectPanel: (key: PanelKey) => void;
 }
 
-export default function LeftPanel({ player }: LeftPanelProps) {
-  const [showDetail, setShowDetail] = useState(false);
+export default function LeftPanel({ player, activePanel, onSelectPanel }: LeftPanelProps) {
   const realm = REALMS[player.realmIndex];
   const nextRealm = getNextRealm(player);
   const expProgress = nextRealm
@@ -78,17 +79,17 @@ export default function LeftPanel({ player }: LeftPanelProps) {
       </div>
 
       {/* 详细属性按钮 */}
-      <button className="btn left-detail-btn" onClick={() => setShowDetail(v => !v)}>
+      <button className={`btn left-detail-btn${activePanel === 'status' ? ' panel-btn-active' : ''}`} onClick={() => onSelectPanel('status')}>
         📋 详细属性
       </button>
 
       {/* 浮动详细属性面板 */}
-      {showDetail && (
+      {activePanel === 'status' && (
         <FloatingPanel
           title="详细属性"
           icon="📋"
           width={420}
-          onClose={() => setShowDetail(false)}
+          onClose={() => onSelectPanel('status')}
         >
           <StatusPanel player={player} />
         </FloatingPanel>

--- a/src/components/layout/PanelButtons.tsx
+++ b/src/components/layout/PanelButtons.tsx
@@ -4,7 +4,7 @@
 
 import type { Player } from '../../game/player';
 
-export type PanelKey = 'inventory' | 'shop' | 'crafting' | 'equipment' | 'technique' | 'divine' | 'achievement';
+export type PanelKey = 'inventory' | 'shop' | 'crafting' | 'equipment' | 'technique' | 'divine' | 'achievement' | 'status';
 
 interface PanelDef {
   key: PanelKey;

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -16,7 +16,8 @@ import TechniquePanel from '../panels/TechniquePanel';
 import DivineArtsPanel from '../panels/DivineArtsPanel';
 import AchievementPanel from '../panels/AchievementPanel';
 
-const PANEL_CONFIG: Record<PanelKey, { title: string; icon: string; width?: number }> = {
+// 'status' panel is rendered by LeftPanel, so excluded from this config
+const PANEL_CONFIG: Partial<Record<PanelKey, { title: string; icon: string; width?: number }>> = {
   inventory: { title: '背包', icon: '🎒', width: 380 },
   shop:      { title: '商店', icon: '🏪', width: 380 },
   technique: { title: '功法', icon: '📖', width: 400 },


### PR DESCRIPTION
## 问题
点击「功法」等右侧面板后，再点左侧「详细属性」，两个浮动窗口会同时出现叠加，体验不好。

## 修复
将「详细属性」纳入统一的 `activePanel` 状态管理，所有浮动面板全局互斥，同一时间只能打开一个。

### 改动
- `PanelKey` 增加 `'status'` 类型
- `LeftPanel` 移除独立 `showDetail` state，改用 `activePanel` / `onSelectPanel` props
- `App.tsx` 传递 `activePanel` 和 `handleSelectPanel` 给 `LeftPanel`
- `RightPanel` 的 `PANEL_CONFIG` 改为 `Partial<Record>` 兼容 `status`

4 files changed, 12 insertions(+), 8 deletions(-)