### PR TITLE
feat(T0059): 体修系统核心 — 数据驱动 DLC 架构

### DIFF
--- a/docs/specs/T0059-body-tuning-guide.md
+++ b/docs/specs/T0059-body-tuning-guide.md
@@ -1,0 +1,207 @@
+# 体修系统数值调整指南（T0059）
+
+> 本文档面向 @Content / @PM / 未来 Agent，说明如何**只改数据文件**来调整体修系统数值，无需修改任何系统代码。
+
+---
+
+## 架构概览
+
+```
+数据层（改这里）                    系统层（不要动）
+─────────────────                ─────────────────
+src/data/core-body-config.ts     src/game/body-cultivation.ts
+  ├─ CORE_BODY_REALMS            src/game/player/stats.ts
+  └─ CORE_SPIRIT_ROOT_BONUSES    src/game/combat/damage.ts
+
+src/data/core-techniques.json    src/game/technique.ts
+  └─ 每条功法的 bodyExpRate
+```
+
+所有数值通过 `registerDLC()` 注册到全局注册表，系统代码只读注册表。
+
+---
+
+## 1. 调整体修境界数值
+
+**文件**：`src/data/core-body-config.ts` → `CORE_BODY_REALMS` 数组
+
+每个境界是一个 `BodyRealmDef` 对象：
+
+```typescript
+{
+  id: 'core:body_iron',        // 唯一 ID（命名空间:名称）
+  name: '铁骨',                // 显示名称（中文）
+  index: 2,                    // 境界索引（0=凡躯，依次递增）
+  maxPhysique: 400,            // 该境界的体魄上限
+  expReq: 500,                 // 从上一阶突破到此阶所需体修修为
+  physiqueDmgReduce: 5,        // 该境界提供的减伤百分比（上限 50）
+  hpBonus: 150,                // 额外 HP 加成
+  atkBonus: 15,                // 额外攻击加成
+  defBonus: 15,                // 额外防御加成
+  description: '骨骼坚硬如铁，拳力大增。',
+}
+```
+
+### 当前 7 阶数值总览
+
+| Index | 名称 | 体魄上限 | 修为要求 | 减伤% | HP+ | ATK+ | DEF+ |
+|-------|------|---------|---------|------|-----|------|------|
+| 0 | 凡躯 | 50 | 0 | 0 | 0 | 0 | 0 |
+| 1 | 铜皮 | 150 | 100 | 2 | 50 | 5 | 5 |
+| 2 | 铁骨 | 400 | 500 | 5 | 150 | 15 | 15 |
+| 3 | 玉髓 | 1000 | 2000 | 10 | 400 | 40 | 35 |
+| 4 | 金刚 | 2500 | 8000 | 18 | 1000 | 90 | 80 |
+| 5 | 龙象 | 6000 | 30000 | 28 | 2500 | 200 | 180 |
+| 6 | 不灭 | 15000 | 100000 | 40 | 6000 | 450 | 400 |
+
+### 调整示例
+
+**想让铁骨更强**：改 `index: 2` 那条的数字即可。
+
+**想加第 8 阶**：在数组末尾追加 `{ ..., index: 7, ... }`。
+
+**突破条件**：
+- `bodyRealmExp >= nextRealm.expReq`（体修修为达标）
+- `physique >= maxPhysique * 0.8`（体魄值至少 80% 满）
+
+---
+
+## 2. 调整灵根对体修的影响
+
+**文件**：`src/data/core-body-config.ts` → `CORE_SPIRIT_ROOT_BODY_BONUSES` 数组
+
+每条是一个 `SpiritRootBodyBonus` 对象：
+
+```typescript
+{
+  rootType: 'metal',             // 灵根类型：metal/wood/water/fire/earth
+  bodyExpMultiplier: 1.3,        // 体修修为获取倍率（1.3 = +30%）
+  physiqueRegenRate: 1.0,        // 体魄恢复速率倍率（1.0 = 无加成）
+  dmgReduceBonus: 0,             // 额外减伤%（叠加到体修境界减伤上）
+  hpBonusRate: 0,                // HP 加成比例（0.15 = +15%）
+}
+```
+
+> **注意**：所有灵根加成都按**亲和度加权**。亲和度 50 的金灵根只给 `0.3 × 50/100 = 15%` 修为加成，而不是完整 30%。
+
+### 当前灵根加成
+
+| 灵根 | 修为倍率 | 恢复速率 | 额外减伤 | HP加成 | 设计意图 |
+|------|---------|---------|---------|--------|---------|
+| 金 metal | ×1.3 | — | — | — | 金主锐利坚韧，加速体修 |
+| 火 fire | ×1.2 | — | — | — | 火锻肉身 |
+| 土 earth | ×1.1 | ×1.3 | +2% | — | 厚重防御型 |
+| 水 water | — | ×1.2 | — | +5% | 生机恢复 |
+| 木 wood | — | ×1.1 | — | +15% | HP 成长型 |
+
+### 调整示例
+
+**想让水灵根也给体修修为**：给 `rootType: 'water'` 加上 `bodyExpMultiplier: 1.15` 即可。
+
+**想删除木灵根的 HP 加成**：把 `hpBonusRate` 改为 `0` 或删掉该字段。
+
+---
+
+## 3. 调整功法的体修修为系数
+
+**文件**：`src/data/core-techniques.json`
+
+每条功法中的 `bodyExpRate` 字段决定修炼该功法时获得多少体修修为：
+
+```json
+{
+  "id": "core:basic_fist",
+  "type": "fist",
+  "bodyExpRate": 1.0,    // ← 这个字段
+  ...
+}
+```
+
+**公式**：`体修修为 = floor(功法熟练度增长 × bodyExpRate × 灵根修为倍率)`
+
+### 当前功法体修系数
+
+| 功法类型 | bodyExpRate | 设计意图 |
+|---------|-----------|---------|
+| fist 拳法 | **1.0** | 纯肉身锤炼，体修主力 |
+| finger 指法 | **0.8** | 指力修炼 |
+| palm 掌法 | **0.6** | 半气半体 |
+| blade 刀法 | **0.4** | 刚猛有体修成分 |
+| spear 枪法 | **0.3** | 偏技巧+力量 |
+| sword 剑法 | **0.2** | 最偏气修，体修最少 |
+
+### 调整示例
+
+**想让剑法完全不给体修修为**：把对应功法的 `bodyExpRate` 改为 `0`。
+
+**某个特定功法是体修专属**：给它 `bodyExpRate: 1.5`（比拳法还高）。
+
+**注意**：`bodyExpRate` 是每条功法独立的，同类型不同功法可以有不同值。JSON 里改了就生效。
+
+---
+
+## 4. DLC 扩展体修内容
+
+未来 DLC 可以通过 `registerDLC()` 挂载自己的体修数据，无需改核心代码：
+
+```typescript
+registerDLC({
+  id: 'dlc-body-master',
+  name: '体修大师扩展包',
+  version: '1.0.0',
+  description: '新增 3 个高阶体修境界 + 调整灵根加成',
+
+  // 新增/覆盖体修境界（按 index 注册，相同 index 会覆盖核心包）
+  bodyRealms: [
+    { id: 'dlc:body_sage', name: '圣体', index: 7, ... },
+    { id: 'dlc:body_chaos', name: '混沌', index: 8, ... },
+  ],
+
+  // 新增/覆盖灵根加成（按 rootType 注册，相同 rootType 覆盖）
+  spiritRootBodyBonuses: [
+    { rootType: 'metal', bodyExpMultiplier: 1.5 },  // 覆盖核心包金灵根
+  ],
+
+  // 新功法自带 bodyExpRate
+  techniques: [
+    { id: 'dlc:chaos_fist', type: 'fist', bodyExpRate: 1.5, ... },
+  ],
+
+  // 体修武器（带 techType + physiqueBonusRate）
+  equips: [
+    {
+      id: 'dlc:dragon_gauntlet',
+      slot: 'weapon',
+      techType: ['fist'],              // 兼容拳法
+      physiqueBonusRate: 0.08,         // 体魄×8% 追加攻击
+      stats: { atk: 30, physique: 200, physiqueDmgReduce: 3 },
+      ...
+    },
+  ],
+});
+```
+
+---
+
+## 5. 快速检查清单
+
+改完数值后确认以下几点：
+
+- [ ] `physiqueDmgReduce` 总和是否可能超过 50（系统有 cap，但数据应合理）
+- [ ] 境界 `index` 是否连续（0,1,2,3...），不能跳号
+- [ ] `expReq` 是否递增（低阶 < 高阶）
+- [ ] `bodyExpRate` 在 0~2 范围内（0=不给体修修为，>1=超强体修功法）
+- [ ] 灵根倍率是否合理（建议单项不超过 ×1.5，避免叠加后过强）
+- [ ] 运行 `npx tsc --noEmit` 确认 TS 数据文件无语法错误
+
+---
+
+## 6. 关键系统逻辑（只读，不要改）
+
+| 文件 | 功能 | 读取的数据 |
+|------|------|-----------|
+| `src/game/body-cultivation.ts` | 突破判定、属性计算、灵根加成 | bodyRealmRegistry, spiritRootBodyBonusRegistry |
+| `src/game/player/stats.ts` | recalcStats 叠加体修属性 | 调用 getBodyRealmBonus() |
+| `src/game/combat/damage.ts` | 第 5 层减伤 | 读 defender.physiqueDmgReduce |
+| `src/game/combat/run.ts` | 武器匹配 + 战斗体修修为 | 读 EquipDef.techType/physiqueBonusRate |
+| `src/game/technique.ts` | 修炼时给体修修为 | 读 TechniqueDef.bodyExpRate |

--- a/src/data/core-body-config.ts
+++ b/src/data/core-body-config.ts
@@ -1,0 +1,53 @@
+// ============================================================
+// data/core-body-config.ts — 体修核心数据（T0059）
+// 体修境界 + 灵根体修加成，全部通过 registerDLC() 注册。
+// 调数值只改此文件，不需要动系统代码。
+// ============================================================
+
+import type { BodyRealmDef, SpiritRootBodyBonus } from '../game/types';
+
+// ── 7 阶体修境界定义 ──
+
+export const CORE_BODY_REALMS: BodyRealmDef[] = [
+  { id: 'core:body_mortal',   name: '凡躯', index: 0, maxPhysique: 50,    expReq: 0,      physiqueDmgReduce: 0,  hpBonus: 0,    atkBonus: 0,   defBonus: 0,   description: '凡人之躯，未经淬炼。' },
+  { id: 'core:body_copper',   name: '铜皮', index: 1, maxPhysique: 150,   expReq: 100,    physiqueDmgReduce: 2,  hpBonus: 50,   atkBonus: 5,   defBonus: 5,   description: '皮肤坚韧如铜，初窥体修门径。' },
+  { id: 'core:body_iron',     name: '铁骨', index: 2, maxPhysique: 400,   expReq: 500,    physiqueDmgReduce: 5,  hpBonus: 150,  atkBonus: 15,  defBonus: 15,  description: '骨骼坚硬如铁，拳力大增。' },
+  { id: 'core:body_jade',     name: '玉髓', index: 3, maxPhysique: 1000,  expReq: 2000,   physiqueDmgReduce: 10, hpBonus: 400,  atkBonus: 40,  defBonus: 35,  description: '筋脉如玉，气血充盈，刀剑难伤。' },
+  { id: 'core:body_diamond',  name: '金刚', index: 4, maxPhysique: 2500,  expReq: 8000,   physiqueDmgReduce: 18, hpBonus: 1000, atkBonus: 90,  defBonus: 80,  description: '金刚不坏之体，力可碎石。' },
+  { id: 'core:body_dragon',   name: '龙象', index: 5, maxPhysique: 6000,  expReq: 30000,  physiqueDmgReduce: 28, hpBonus: 2500, atkBonus: 200, defBonus: 180, description: '龙象之力灌体，万夫不当。' },
+  { id: 'core:body_immortal', name: '不灭', index: 6, maxPhysique: 15000, expReq: 100000, physiqueDmgReduce: 40, hpBonus: 6000, atkBonus: 450, defBonus: 400, description: '不灭真体，天地难毁。' },
+];
+
+// ── 灵根对体修的加成配置 ──
+// 改这里就能调整灵根和体修的联动强度
+
+export const CORE_SPIRIT_ROOT_BODY_BONUSES: SpiritRootBodyBonus[] = [
+  {
+    rootType: 'metal',
+    bodyExpMultiplier: 1.3,        // 金灵根：金主锐利坚韧，体修修为 +30%
+    physiqueRegenRate: 1.0,
+  },
+  {
+    rootType: 'earth',
+    bodyExpMultiplier: 1.1,
+    physiqueRegenRate: 1.3,        // 土灵根：土主厚重，体魄恢复 +30%
+    dmgReduceBonus: 2,             // 额外减伤 +2%
+  },
+  {
+    rootType: 'fire',
+    bodyExpMultiplier: 1.2,        // 火灵根：火锻肉身，体修修为 +20%
+    physiqueRegenRate: 1.0,
+  },
+  {
+    rootType: 'water',
+    bodyExpMultiplier: 1.0,
+    physiqueRegenRate: 1.2,        // 水灵根：水主生机，体魄恢复 +20%
+    hpBonusRate: 0.05,             // HP 加成 +5%
+  },
+  {
+    rootType: 'wood',
+    bodyExpMultiplier: 1.0,
+    physiqueRegenRate: 1.1,
+    hpBonusRate: 0.15,             // 木灵根：木主生长，HP 加成 +15%
+  },
+];

--- a/src/data/core-techniques.json
+++ b/src/data/core-techniques.json
@@ -8,11 +8,24 @@
     "minRealm": 0,
     "maxLevel": 10,
     "expPerLevel": 50,
-    "statBonusPerLevel": { "atk": 3, "speed": 1 },
+    "statBonusPerLevel": {
+      "atk": 3,
+      "speed": 1
+    },
     "aptitudeKey": "sword",
     "passiveEffects": [
-      { "minLevel": 3, "stat": "atk",   "value": 8, "description": "剑心初启：攻击 +8" },
-      { "minLevel": 7, "stat": "speed", "value": 5, "description": "剑意流动：速度 +5" }
+      {
+        "minLevel": 3,
+        "stat": "atk",
+        "value": 8,
+        "description": "剑心初启：攻击 +8"
+      },
+      {
+        "minLevel": 7,
+        "stat": "speed",
+        "value": 5,
+        "description": "剑意流动：速度 +5"
+      }
     ],
     "activeSkill": {
       "name": "三才剑诀",
@@ -23,7 +36,8 @@
       "hitCount": 1,
       "cooldown": 0,
       "triggerRate": 0.35
-    }
+    },
+    "bodyExpRate": 0.2
   },
   {
     "id": "core:basic_blade",
@@ -34,11 +48,23 @@
     "minRealm": 0,
     "maxLevel": 10,
     "expPerLevel": 50,
-    "statBonusPerLevel": { "atk": 4 },
+    "statBonusPerLevel": {
+      "atk": 4
+    },
     "aptitudeKey": "blade",
     "passiveEffects": [
-      { "minLevel": 3, "stat": "atk", "value": 10, "description": "刀势初成：攻击 +10" },
-      { "minLevel": 7, "stat": "def", "value": 5,  "description": "铁骨精神：防御 +5" }
+      {
+        "minLevel": 3,
+        "stat": "atk",
+        "value": 10,
+        "description": "刀势初成：攻击 +10"
+      },
+      {
+        "minLevel": 7,
+        "stat": "def",
+        "value": 5,
+        "description": "铁骨精神：防御 +5"
+      }
     ],
     "activeSkill": {
       "name": "劈山斩",
@@ -48,8 +74,9 @@
       "dmgMultiplier": 1.5,
       "hitCount": 1,
       "cooldown": 1,
-      "triggerRate": 0.30
-    }
+      "triggerRate": 0.3
+    },
+    "bodyExpRate": 0.4
   },
   {
     "id": "core:basic_fist",
@@ -60,12 +87,25 @@
     "minRealm": 0,
     "maxLevel": 10,
     "expPerLevel": 50,
-    "statBonusPerLevel": { "atk": 2, "hp": 10 },
+    "statBonusPerLevel": {
+      "atk": 2,
+      "hp": 10
+    },
     "aptitudeKey": "fist",
     "spiritRootElement": "earth",
     "passiveEffects": [
-      { "minLevel": 3, "stat": "hp",  "value": 30, "description": "体魄强健：体力 +30" },
-      { "minLevel": 7, "stat": "atk", "value": 6,  "description": "拳意精通：攻击 +6" }
+      {
+        "minLevel": 3,
+        "stat": "hp",
+        "value": 30,
+        "description": "体魄强健：体力 +30"
+      },
+      {
+        "minLevel": 7,
+        "stat": "atk",
+        "value": 6,
+        "description": "拳意精通：攻击 +6"
+      }
     ],
     "activeSkill": {
       "name": "连环拳",
@@ -75,8 +115,9 @@
       "dmgMultiplier": 1.0,
       "hitCount": 3,
       "cooldown": 1,
-      "triggerRate": 0.30
-    }
+      "triggerRate": 0.3
+    },
+    "bodyExpRate": 1.0
   },
   {
     "id": "core:basic_palm",
@@ -87,12 +128,25 @@
     "minRealm": 0,
     "maxLevel": 10,
     "expPerLevel": 50,
-    "statBonusPerLevel": { "atk": 2, "def": 2 },
+    "statBonusPerLevel": {
+      "atk": 2,
+      "def": 2
+    },
     "aptitudeKey": "palm",
     "spiritRootElement": "water",
     "passiveEffects": [
-      { "minLevel": 3, "stat": "def", "value": 8,  "description": "柔劲护体：防御 +8" },
-      { "minLevel": 7, "stat": "mp",  "value": 20, "description": "内力绵延：灵力 +20" }
+      {
+        "minLevel": 3,
+        "stat": "def",
+        "value": 8,
+        "description": "柔劲护体：防御 +8"
+      },
+      {
+        "minLevel": 7,
+        "stat": "mp",
+        "value": 20,
+        "description": "内力绵延：灵力 +20"
+      }
     ],
     "activeSkill": {
       "name": "柔云掌",
@@ -103,8 +157,13 @@
       "hitCount": 1,
       "cooldown": 0,
       "triggerRate": 0.35,
-      "effect": { "type": "heal_self", "value": 15, "duration": 1 }
-    }
+      "effect": {
+        "type": "heal_self",
+        "value": 15,
+        "duration": 1
+      }
+    },
+    "bodyExpRate": 0.6
   },
   {
     "id": "core:basic_finger",
@@ -115,12 +174,25 @@
     "minRealm": 0,
     "maxLevel": 10,
     "expPerLevel": 50,
-    "statBonusPerLevel": { "atk": 2, "critRate": 1 },
+    "statBonusPerLevel": {
+      "atk": 2,
+      "critRate": 1
+    },
     "aptitudeKey": "finger",
     "spiritRootElement": "metal",
     "passiveEffects": [
-      { "minLevel": 3, "stat": "critRate", "value": 2, "description": "指法精准：暴击率 +2%" },
-      { "minLevel": 7, "stat": "atk",      "value": 8, "description": "一指锁喉：攻击 +8" }
+      {
+        "minLevel": 3,
+        "stat": "critRate",
+        "value": 2,
+        "description": "指法精准：暴击率 +2%"
+      },
+      {
+        "minLevel": 7,
+        "stat": "atk",
+        "value": 8,
+        "description": "一指锁喉：攻击 +8"
+      }
     ],
     "activeSkill": {
       "name": "一阳指",
@@ -130,8 +202,9 @@
       "dmgMultiplier": 1.4,
       "hitCount": 1,
       "cooldown": 1,
-      "triggerRate": 0.30
-    }
+      "triggerRate": 0.3
+    },
+    "bodyExpRate": 0.8
   },
   {
     "id": "core:basic_spear",
@@ -142,12 +215,25 @@
     "minRealm": 0,
     "maxLevel": 10,
     "expPerLevel": 50,
-    "statBonusPerLevel": { "atk": 3, "def": 1 },
+    "statBonusPerLevel": {
+      "atk": 3,
+      "def": 1
+    },
     "aptitudeKey": "spear",
     "spiritRootElement": "wood",
     "passiveEffects": [
-      { "minLevel": 3, "stat": "atk", "value": 8, "description": "枪势初展：攻击 +8" },
-      { "minLevel": 7, "stat": "def", "value": 6, "description": "枪盾合一：防御 +6" }
+      {
+        "minLevel": 3,
+        "stat": "atk",
+        "value": 8,
+        "description": "枪势初展：攻击 +8"
+      },
+      {
+        "minLevel": 7,
+        "stat": "def",
+        "value": 6,
+        "description": "枪盾合一：防御 +6"
+      }
     ],
     "activeSkill": {
       "name": "破阵枪",
@@ -157,9 +243,14 @@
       "dmgMultiplier": 1.4,
       "hitCount": 1,
       "cooldown": 0,
-      "triggerRate": 0.30,
-      "effect": { "type": "debuff_def", "value": 3, "duration": 2 }
-    }
+      "triggerRate": 0.3,
+      "effect": {
+        "type": "debuff_def",
+        "value": 3,
+        "duration": 2
+      }
+    },
+    "bodyExpRate": 0.3
   },
   {
     "id": "core:swift_sword",
@@ -170,13 +261,32 @@
     "minRealm": 1,
     "maxLevel": 15,
     "expPerLevel": 80,
-    "statBonusPerLevel": { "atk": 4, "speed": 2, "critRate": 1 },
+    "statBonusPerLevel": {
+      "atk": 4,
+      "speed": 2,
+      "critRate": 1
+    },
     "aptitudeKey": "sword",
     "spiritRootElement": "metal",
     "passiveEffects": [
-      { "minLevel": 3,  "stat": "speed",    "value": 8,  "description": "疾风步法：速度 +8" },
-      { "minLevel": 8,  "stat": "atk",      "value": 12, "description": "风刃锋利：攻击 +12" },
-      { "minLevel": 12, "stat": "critRate", "value": 3,  "description": "疾风暴击：暴击率 +3%" }
+      {
+        "minLevel": 3,
+        "stat": "speed",
+        "value": 8,
+        "description": "疾风步法：速度 +8"
+      },
+      {
+        "minLevel": 8,
+        "stat": "atk",
+        "value": 12,
+        "description": "风刃锋利：攻击 +12"
+      },
+      {
+        "minLevel": 12,
+        "stat": "critRate",
+        "value": 3,
+        "description": "疾风暴击：暴击率 +3%"
+      }
     ],
     "activeSkill": {
       "name": "疾风三剑",
@@ -187,7 +297,8 @@
       "hitCount": 3,
       "cooldown": 2,
       "triggerRate": 0.35
-    }
+    },
+    "bodyExpRate": 0.2
   },
   {
     "id": "core:iron_fist",
@@ -198,13 +309,32 @@
     "minRealm": 1,
     "maxLevel": 15,
     "expPerLevel": 80,
-    "statBonusPerLevel": { "atk": 3, "def": 2, "hp": 15 },
+    "statBonusPerLevel": {
+      "atk": 3,
+      "def": 2,
+      "hp": 15
+    },
     "aptitudeKey": "fist",
     "spiritRootElement": "earth",
     "passiveEffects": [
-      { "minLevel": 3,  "stat": "hp",  "value": 50, "description": "铁骨皮肉：体力 +50" },
-      { "minLevel": 8,  "stat": "atk", "value": 15, "description": "铁拳贯穿：攻击 +15" },
-      { "minLevel": 12, "stat": "def", "value": 12, "description": "金刚不坏：防御 +12" }
+      {
+        "minLevel": 3,
+        "stat": "hp",
+        "value": 50,
+        "description": "铁骨皮肉：体力 +50"
+      },
+      {
+        "minLevel": 8,
+        "stat": "atk",
+        "value": 15,
+        "description": "铁拳贯穿：攻击 +15"
+      },
+      {
+        "minLevel": 12,
+        "stat": "def",
+        "value": 12,
+        "description": "金刚不坏：防御 +12"
+      }
     ],
     "activeSkill": {
       "name": "崩山拳",
@@ -214,9 +344,14 @@
       "dmgMultiplier": 1.8,
       "hitCount": 1,
       "cooldown": 2,
-      "triggerRate": 0.30,
-      "effect": { "type": "debuff_def", "value": 5, "duration": 2 }
-    }
+      "triggerRate": 0.3,
+      "effect": {
+        "type": "debuff_def",
+        "value": 5,
+        "duration": 2
+      }
+    },
+    "bodyExpRate": 1.0
   },
   {
     "id": "core:thunder_blade",
@@ -227,13 +362,32 @@
     "minRealm": 2,
     "maxLevel": 20,
     "expPerLevel": 120,
-    "statBonusPerLevel": { "atk": 6, "critRate": 2, "critDmgMultiplier": 0.05 },
+    "statBonusPerLevel": {
+      "atk": 6,
+      "critRate": 2,
+      "critDmgMultiplier": 0.05
+    },
     "aptitudeKey": "blade",
     "spiritRootElement": "metal",
     "passiveEffects": [
-      { "minLevel": 5,  "stat": "atk",              "value": 20,  "description": "雷威：攻击 +20" },
-      { "minLevel": 10, "stat": "critRate",          "value": 5,   "description": "霆击必中：暴击率 +5%" },
-      { "minLevel": 15, "stat": "critDmgMultiplier", "value": 0.2, "description": "天雷斩杀：暴击伤害 +20%" }
+      {
+        "minLevel": 5,
+        "stat": "atk",
+        "value": 20,
+        "description": "雷威：攻击 +20"
+      },
+      {
+        "minLevel": 10,
+        "stat": "critRate",
+        "value": 5,
+        "description": "霆击必中：暴击率 +5%"
+      },
+      {
+        "minLevel": 15,
+        "stat": "critDmgMultiplier",
+        "value": 0.2,
+        "description": "天雷斩杀：暴击伤害 +20%"
+      }
     ],
     "activeSkill": {
       "name": "天雷斩",
@@ -244,8 +398,13 @@
       "hitCount": 1,
       "cooldown": 3,
       "triggerRate": 0.25,
-      "effect": { "type": "dot", "value": 30, "duration": 3 }
-    }
+      "effect": {
+        "type": "dot",
+        "value": 30,
+        "duration": 3
+      }
+    },
+    "bodyExpRate": 0.4
   },
   {
     "id": "core:phantom_palm",
@@ -256,13 +415,32 @@
     "minRealm": 2,
     "maxLevel": 20,
     "expPerLevel": 120,
-    "statBonusPerLevel": { "atk": 4, "speed": 3, "def": 2 },
+    "statBonusPerLevel": {
+      "atk": 4,
+      "speed": 3,
+      "def": 2
+    },
     "aptitudeKey": "palm",
     "spiritRootElement": "water",
     "passiveEffects": [
-      { "minLevel": 5,  "stat": "speed", "value": 15, "description": "幻影身法：速度 +15" },
-      { "minLevel": 10, "stat": "atk",   "value": 18, "description": "幻掌虚实：攻击 +18" },
-      { "minLevel": 15, "stat": "def",   "value": 15, "description": "幻盾护体：防御 +15" }
+      {
+        "minLevel": 5,
+        "stat": "speed",
+        "value": 15,
+        "description": "幻影身法：速度 +15"
+      },
+      {
+        "minLevel": 10,
+        "stat": "atk",
+        "value": 18,
+        "description": "幻掌虚实：攻击 +18"
+      },
+      {
+        "minLevel": 15,
+        "stat": "def",
+        "value": 15,
+        "description": "幻盾护体：防御 +15"
+      }
     ],
     "activeSkill": {
       "name": "幻影连击",
@@ -273,7 +451,8 @@
       "hitCount": 5,
       "cooldown": 3,
       "triggerRate": 0.25
-    }
+    },
+    "bodyExpRate": 0.6
   },
   {
     "id": "core:heaven_sword",
@@ -284,13 +463,33 @@
     "minRealm": 3,
     "maxLevel": 25,
     "expPerLevel": 200,
-    "statBonusPerLevel": { "atk": 8, "speed": 3, "critRate": 2, "mp": 10 },
+    "statBonusPerLevel": {
+      "atk": 8,
+      "speed": 3,
+      "critRate": 2,
+      "mp": 10
+    },
     "aptitudeKey": "sword",
     "spiritRootElement": "fire",
     "passiveEffects": [
-      { "minLevel": 5,  "stat": "atk",              "value": 30,  "description": "天罡锋锐：攻击 +30" },
-      { "minLevel": 10, "stat": "critRate",          "value": 8,   "description": "罡气贯心：暴击率 +8%" },
-      { "minLevel": 18, "stat": "critDmgMultiplier", "value": 0.3, "description": "剑道极意：暴击伤害 +30%" }
+      {
+        "minLevel": 5,
+        "stat": "atk",
+        "value": 30,
+        "description": "天罡锋锐：攻击 +30"
+      },
+      {
+        "minLevel": 10,
+        "stat": "critRate",
+        "value": 8,
+        "description": "罡气贯心：暴击率 +8%"
+      },
+      {
+        "minLevel": 18,
+        "stat": "critDmgMultiplier",
+        "value": 0.3,
+        "description": "剑道极意：暴击伤害 +30%"
+      }
     ],
     "activeSkill": {
       "name": "万剑归宗",
@@ -300,9 +499,14 @@
       "dmgMultiplier": 1.5,
       "hitCount": 4,
       "cooldown": 4,
-      "triggerRate": 0.20,
-      "effect": { "type": "dot", "value": 50, "duration": 3 }
-    }
+      "triggerRate": 0.2,
+      "effect": {
+        "type": "dot",
+        "value": 50,
+        "duration": 3
+      }
+    },
+    "bodyExpRate": 0.2
   },
   {
     "id": "core:dragon_spear",
@@ -313,13 +517,33 @@
     "minRealm": 3,
     "maxLevel": 25,
     "expPerLevel": 200,
-    "statBonusPerLevel": { "atk": 7, "def": 3, "speed": 2, "hp": 20 },
+    "statBonusPerLevel": {
+      "atk": 7,
+      "def": 3,
+      "speed": 2,
+      "hp": 20
+    },
     "aptitudeKey": "spear",
     "spiritRootElement": "wood",
     "passiveEffects": [
-      { "minLevel": 5,  "stat": "def", "value": 25,  "description": "龙鳞护甲：防御 +25" },
-      { "minLevel": 10, "stat": "atk", "value": 28,  "description": "龙吟破甲：攻击 +28" },
-      { "minLevel": 18, "stat": "hp",  "value": 150, "description": "龙血战体：体力 +150" }
+      {
+        "minLevel": 5,
+        "stat": "def",
+        "value": 25,
+        "description": "龙鳞护甲：防御 +25"
+      },
+      {
+        "minLevel": 10,
+        "stat": "atk",
+        "value": 28,
+        "description": "龙吟破甲：攻击 +28"
+      },
+      {
+        "minLevel": 18,
+        "stat": "hp",
+        "value": 150,
+        "description": "龙血战体：体力 +150"
+      }
     ],
     "activeSkill": {
       "name": "龙吟贯日",
@@ -329,9 +553,14 @@
       "dmgMultiplier": 2.5,
       "hitCount": 1,
       "cooldown": 4,
-      "triggerRate": 0.20,
-      "effect": { "type": "debuff_atk", "value": 20, "duration": 3 }
-    }
+      "triggerRate": 0.2,
+      "effect": {
+        "type": "debuff_atk",
+        "value": 20,
+        "duration": 3
+      }
+    },
+    "bodyExpRate": 0.3
   },
   {
     "id": "core:flame_fist",
@@ -342,14 +571,32 @@
     "minRealm": 1,
     "maxLevel": 20,
     "expPerLevel": 100,
-    "statBonusPerLevel": { "atk": 5, "hp": 8 },
+    "statBonusPerLevel": {
+      "atk": 5,
+      "hp": 8
+    },
     "aptitudeKey": "fist",
     "spiritRootElement": "fire",
     "requiredSpiritRoot": "fire",
     "passiveEffects": [
-      { "minLevel": 4,  "stat": "atk", "value": 15, "description": "焰心开窍：攻击 +15" },
-      { "minLevel": 10, "stat": "hp",  "value": 60, "description": "火体淬炼：体力 +60" },
-      { "minLevel": 16, "stat": "critRate", "value": 5, "description": "烈焰暴击：暴击率 +5%" }
+      {
+        "minLevel": 4,
+        "stat": "atk",
+        "value": 15,
+        "description": "焰心开窍：攻击 +15"
+      },
+      {
+        "minLevel": 10,
+        "stat": "hp",
+        "value": 60,
+        "description": "火体淬炼：体力 +60"
+      },
+      {
+        "minLevel": 16,
+        "stat": "critRate",
+        "value": 5,
+        "description": "烈焰暴击：暴击率 +5%"
+      }
     ],
     "activeSkill": {
       "name": "燎原拳",
@@ -359,9 +606,14 @@
       "dmgMultiplier": 1.6,
       "hitCount": 1,
       "cooldown": 2,
-      "triggerRate": 0.30,
-      "effect": { "type": "dot", "value": 25, "duration": 3 }
-    }
+      "triggerRate": 0.3,
+      "effect": {
+        "type": "dot",
+        "value": 25,
+        "duration": 3
+      }
+    },
+    "bodyExpRate": 1.0
   },
   {
     "id": "core:water_sword",
@@ -372,14 +624,33 @@
     "minRealm": 1,
     "maxLevel": 20,
     "expPerLevel": 100,
-    "statBonusPerLevel": { "atk": 4, "def": 3, "mp": 8 },
+    "statBonusPerLevel": {
+      "atk": 4,
+      "def": 3,
+      "mp": 8
+    },
     "aptitudeKey": "sword",
     "spiritRootElement": "water",
     "requiredSpiritRoot": "water",
     "passiveEffects": [
-      { "minLevel": 4,  "stat": "mp",  "value": 30, "description": "水源充沛：灵力 +30" },
-      { "minLevel": 10, "stat": "def", "value": 18, "description": "水盾护身：防御 +18" },
-      { "minLevel": 16, "stat": "atk", "value": 20, "description": "水剑锋利：攻击 +20" }
+      {
+        "minLevel": 4,
+        "stat": "mp",
+        "value": 30,
+        "description": "水源充沛：灵力 +30"
+      },
+      {
+        "minLevel": 10,
+        "stat": "def",
+        "value": 18,
+        "description": "水盾护身：防御 +18"
+      },
+      {
+        "minLevel": 16,
+        "stat": "atk",
+        "value": 20,
+        "description": "水剑锋利：攻击 +20"
+      }
     ],
     "activeSkill": {
       "name": "百川归海",
@@ -390,8 +661,13 @@
       "hitCount": 5,
       "cooldown": 3,
       "triggerRate": 0.28,
-      "effect": { "type": "heal_self", "value": 20, "duration": 1 }
-    }
+      "effect": {
+        "type": "heal_self",
+        "value": 20,
+        "duration": 1
+      }
+    },
+    "bodyExpRate": 0.2
   },
   {
     "id": "core:earth_palm",
@@ -402,14 +678,33 @@
     "minRealm": 1,
     "maxLevel": 20,
     "expPerLevel": 100,
-    "statBonusPerLevel": { "atk": 3, "def": 4, "hp": 12 },
+    "statBonusPerLevel": {
+      "atk": 3,
+      "def": 4,
+      "hp": 12
+    },
     "aptitudeKey": "palm",
     "spiritRootElement": "earth",
     "requiredSpiritRoot": "earth",
     "passiveEffects": [
-      { "minLevel": 4,  "stat": "def", "value": 20, "description": "厚土护体：防御 +20" },
-      { "minLevel": 10, "stat": "hp",  "value": 80, "description": "磐石体魄：体力 +80" },
-      { "minLevel": 16, "stat": "atk", "value": 18, "description": "岩破万法：攻击 +18" }
+      {
+        "minLevel": 4,
+        "stat": "def",
+        "value": 20,
+        "description": "厚土护体：防御 +20"
+      },
+      {
+        "minLevel": 10,
+        "stat": "hp",
+        "value": 80,
+        "description": "磐石体魄：体力 +80"
+      },
+      {
+        "minLevel": 16,
+        "stat": "atk",
+        "value": 18,
+        "description": "岩破万法：攻击 +18"
+      }
     ],
     "activeSkill": {
       "name": "泰山压顶",
@@ -420,8 +715,13 @@
       "hitCount": 1,
       "cooldown": 3,
       "triggerRate": 0.28,
-      "effect": { "type": "debuff_def", "value": 8, "duration": 3 }
-    }
+      "effect": {
+        "type": "debuff_def",
+        "value": 8,
+        "duration": 3
+      }
+    },
+    "bodyExpRate": 0.6
   },
   {
     "id": "core:metal_blade",
@@ -432,14 +732,32 @@
     "minRealm": 1,
     "maxLevel": 20,
     "expPerLevel": 100,
-    "statBonusPerLevel": { "atk": 6, "critRate": 2 },
+    "statBonusPerLevel": {
+      "atk": 6,
+      "critRate": 2
+    },
     "aptitudeKey": "blade",
     "spiritRootElement": "metal",
     "requiredSpiritRoot": "metal",
     "passiveEffects": [
-      { "minLevel": 4,  "stat": "atk",     "value": 18, "description": "金煞附身：攻击 +18" },
-      { "minLevel": 10, "stat": "critRate", "value": 5,  "description": "金锋决断：暴击率 +5%" },
-      { "minLevel": 16, "stat": "critDmgMultiplier", "value": 0.25, "description": "金煞斩杀：暴击伤害 +25%" }
+      {
+        "minLevel": 4,
+        "stat": "atk",
+        "value": 18,
+        "description": "金煞附身：攻击 +18"
+      },
+      {
+        "minLevel": 10,
+        "stat": "critRate",
+        "value": 5,
+        "description": "金锋决断：暴击率 +5%"
+      },
+      {
+        "minLevel": 16,
+        "stat": "critDmgMultiplier",
+        "value": 0.25,
+        "description": "金煞斩杀：暴击伤害 +25%"
+      }
     ],
     "activeSkill": {
       "name": "金煞一斩",
@@ -450,8 +768,13 @@
       "hitCount": 1,
       "cooldown": 3,
       "triggerRate": 0.28,
-      "effect": { "type": "dot", "value": 20, "duration": 4 }
-    }
+      "effect": {
+        "type": "dot",
+        "value": 20,
+        "duration": 4
+      }
+    },
+    "bodyExpRate": 0.4
   },
   {
     "id": "core:wood_spear",
@@ -462,14 +785,33 @@
     "minRealm": 1,
     "maxLevel": 20,
     "expPerLevel": 100,
-    "statBonusPerLevel": { "atk": 4, "def": 2, "speed": 2 },
+    "statBonusPerLevel": {
+      "atk": 4,
+      "def": 2,
+      "speed": 2
+    },
     "aptitudeKey": "spear",
     "spiritRootElement": "wood",
     "requiredSpiritRoot": "wood",
     "passiveEffects": [
-      { "minLevel": 4,  "stat": "speed", "value": 10, "description": "翠木身法：速度 +10" },
-      { "minLevel": 10, "stat": "atk",   "value": 18, "description": "翠木穿刺：攻击 +18" },
-      { "minLevel": 16, "stat": "def",   "value": 15, "description": "木甲护身：防御 +15" }
+      {
+        "minLevel": 4,
+        "stat": "speed",
+        "value": 10,
+        "description": "翠木身法：速度 +10"
+      },
+      {
+        "minLevel": 10,
+        "stat": "atk",
+        "value": 18,
+        "description": "翠木穿刺：攻击 +18"
+      },
+      {
+        "minLevel": 16,
+        "stat": "def",
+        "value": 15,
+        "description": "木甲护身：防御 +15"
+      }
     ],
     "activeSkill": {
       "name": "枯木逢春",
@@ -479,8 +821,13 @@
       "dmgMultiplier": 1.2,
       "hitCount": 3,
       "cooldown": 2,
-      "triggerRate": 0.30,
-      "effect": { "type": "heal_self", "value": 25, "duration": 1 }
-    }
+      "triggerRate": 0.3,
+      "effect": {
+        "type": "heal_self",
+        "value": 25,
+        "duration": 1
+      }
+    },
+    "bodyExpRate": 0.3
   }
 ]

--- a/src/game/body-cultivation.ts
+++ b/src/game/body-cultivation.ts
@@ -1,0 +1,174 @@
+// ============================================================
+// game/body-cultivation.ts — 体修核心逻辑（T0059）
+// 系统代码只读注册表，不硬编码任何数值。
+// 所有体修境界、灵根加成均通过 DLC 数据注册。
+// ============================================================
+
+import type { Player } from './player';
+import type { BodyRealmDef } from './types';
+import { getBodyRealmDef, getSpiritRootBodyBonus } from './registry/queries';
+
+// ── 查询 ──
+
+/** 获取下一个体修境界 */
+export function getNextBodyRealm(player: Player): BodyRealmDef | undefined {
+  return getBodyRealmDef(player.bodyRealmIndex + 1);
+}
+
+// ── 灵根体修加成计算（从注册表读取数据） ──
+
+/** 计算玩家灵根对体修修为的总倍率 */
+export function getSpiritRootBodyExpMultiplier(player: Player): number {
+  let multiplier = 1.0;
+  if (!player.spiritRoots?.roots) return multiplier;
+  for (const root of player.spiritRoots.roots) {
+    const bonus = getSpiritRootBodyBonus(root.type);
+    if (bonus?.bodyExpMultiplier) {
+      // 按亲和度加权：亲和度越高效果越强
+      const affinityFactor = root.affinity / 100;
+      multiplier += (bonus.bodyExpMultiplier - 1) * affinityFactor;
+    }
+  }
+  return multiplier;
+}
+
+/** 计算灵根对体魄恢复的加成倍率 */
+export function getSpiritRootRegenMultiplier(player: Player): number {
+  let multiplier = 1.0;
+  if (!player.spiritRoots?.roots) return multiplier;
+  for (const root of player.spiritRoots.roots) {
+    const bonus = getSpiritRootBodyBonus(root.type);
+    if (bonus?.physiqueRegenRate) {
+      const affinityFactor = root.affinity / 100;
+      multiplier += (bonus.physiqueRegenRate - 1) * affinityFactor;
+    }
+  }
+  return multiplier;
+}
+
+/** 计算灵根提供的额外减伤 */
+export function getSpiritRootDmgReduceBonus(player: Player): number {
+  let bonus = 0;
+  if (!player.spiritRoots?.roots) return bonus;
+  for (const root of player.spiritRoots.roots) {
+    const def = getSpiritRootBodyBonus(root.type);
+    if (def?.dmgReduceBonus) {
+      bonus += def.dmgReduceBonus * (root.affinity / 100);
+    }
+  }
+  return bonus;
+}
+
+/** 计算灵根提供的 HP 加成比例 */
+export function getSpiritRootHpBonusRate(player: Player): number {
+  let rate = 0;
+  if (!player.spiritRoots?.roots) return rate;
+  for (const root of player.spiritRoots.roots) {
+    const def = getSpiritRootBodyBonus(root.type);
+    if (def?.hpBonusRate) {
+      rate += def.hpBonusRate * (root.affinity / 100);
+    }
+  }
+  return rate;
+}
+
+// ── 体修境界突破 ──
+
+export function tryBodyRealmBreakthrough(player: Player): {
+  player: Player;
+  breakthrough: boolean;
+  message: string;
+} {
+  const nextRealm = getBodyRealmDef(player.bodyRealmIndex + 1);
+  if (!nextRealm) {
+    return { player, breakthrough: false, message: '' };
+  }
+
+  // 条件：体修修为 >= 下一阶要求 AND 体魄 >= 当前上限的 80%
+  if (player.bodyRealmExp < nextRealm.expReq) {
+    return { player, breakthrough: false, message: '' };
+  }
+  if (player.physique < player.maxPhysique * 0.8) {
+    return { player, breakthrough: false, message: '' };
+  }
+
+  const p = { ...player };
+  p.bodyRealmIndex = nextRealm.index;
+  p.bodyRealmExp = 0;
+  p.bodyTempering += 1;
+  // maxPhysique 和 physiqueDmgReduce 在 recalcStats 中统一处理
+  p.maxPhysique = nextRealm.maxPhysique;
+  p.physiqueDmgReduce = nextRealm.physiqueDmgReduce;
+
+  return {
+    player: p,
+    breakthrough: true,
+    message: `🔥 体修突破！肉身淬炼至【${nextRealm.name}】！减伤 ${nextRealm.physiqueDmgReduce}%`,
+  };
+}
+
+// ── 体修修为获取（应用灵根加成 + 功法 bodyExpRate） ──
+
+/** 增加体修修为并自动检查突破 */
+export function gainBodyRealmExp(
+  player: Player,
+  baseAmount: number,
+): { player: Player; message: string; actualGain: number } {
+  // 应用灵根体修修为倍率
+  const multiplier = getSpiritRootBodyExpMultiplier(player);
+  const actualGain = Math.floor(baseAmount * multiplier);
+  if (actualGain <= 0) return { player, message: '', actualGain: 0 };
+
+  let p = { ...player, bodyRealmExp: player.bodyRealmExp + actualGain };
+
+  // 自动突破
+  const btResult = tryBodyRealmBreakthrough(p);
+  if (btResult.breakthrough) {
+    return {
+      player: btResult.player,
+      message: btResult.message,
+      actualGain,
+    };
+  }
+
+  return { player: p, message: '', actualGain };
+}
+
+// ── 体修属性加成（供 recalcStats 调用） ──
+
+export function getBodyRealmBonus(player: Player): {
+  hp: number;
+  atk: number;
+  def: number;
+  maxPhysique: number;
+  physiqueDmgReduce: number;
+} {
+  const realm = getBodyRealmDef(player.bodyRealmIndex);
+  if (!realm) return { hp: 0, atk: 0, def: 0, maxPhysique: 50, physiqueDmgReduce: 0 };
+
+  // 灵根 HP 加成
+  const hpBonusRate = getSpiritRootHpBonusRate(player);
+  const hpBonus = Math.floor(realm.hpBonus * (1 + hpBonusRate));
+
+  // 灵根额外减伤
+  const rootDmgReduce = getSpiritRootDmgReduceBonus(player);
+
+  return {
+    hp: hpBonus,
+    atk: realm.atkBonus,
+    def: realm.defBonus,
+    maxPhysique: realm.maxPhysique,
+    physiqueDmgReduce: realm.physiqueDmgReduce + rootDmgReduce,
+  };
+}
+
+// ── 体魄恢复（休息时调用） ──
+
+export function restorePhysique(player: Player): Player {
+  const regenMultiplier = getSpiritRootRegenMultiplier(player);
+  const restore = Math.floor(player.maxPhysique * 0.1 * regenMultiplier);
+  return {
+    ...player,
+    physique: Math.min(player.maxPhysique, player.physique + restore),
+  };
+}

--- a/src/game/combat/damage.ts
+++ b/src/game/combat/damage.ts
@@ -36,6 +36,12 @@ export function calcDamage(attacker: Combatant, defender: Combatant): DamageResu
     isDodge = true;
   }
 
+  // 5. 体魄减伤（T0059，上限 50%）
+  if (!isDodge && defender.physiqueDmgReduce && defender.physiqueDmgReduce > 0) {
+    const reduceRate = Math.min(0.50, defender.physiqueDmgReduce / 100);
+    dmg = Math.floor(dmg * (1 - reduceRate));
+  }
+
   const finalDmg = Math.floor(dmg);
 
   if (isDodge) {
@@ -96,6 +102,12 @@ export function calcSkillDamage(
     if (Math.random() < dodgeChance) {
       dmg = 0;
       isDodge = true;
+    }
+
+    // 体魄减伤（T0059）
+    if (!isDodge && defender.physiqueDmgReduce && defender.physiqueDmgReduce > 0) {
+      const reduceRate = Math.min(0.50, defender.physiqueDmgReduce / 100);
+      dmg = Math.floor(dmg * (1 - reduceRate));
     }
 
     const finalDmg = Math.floor(dmg);

--- a/src/game/combat/run.ts
+++ b/src/game/combat/run.ts
@@ -3,7 +3,7 @@
 // ============================================================
 
 import type { Player } from '../player';
-import type { MonsterDef } from '../types';
+import type { MonsterDef, TechniqueDef } from '../types';
 import type { SkillState, StatusEffect, CombatResult, RoundSnapshot } from './types';
 import { calcDamage, tryUseSkill, calcSkillDamage } from './damage';
 import { getActiveTechniqueBonus, getActiveSkillInfo, calcAptitudeBonus } from '../technique';
@@ -12,29 +12,43 @@ import {
   ELEMENT_EMOJI, ELEMENT_CN,
 } from '../divine-arts';
 import { getDivineArtDef } from '../registry/queries';
+import { getEquipDef } from '../registry';
 
 export function runCombat(player: Player, monster: MonsterDef): CombatResult {
   const logs: string[] = [];
   const snapshots: RoundSnapshot[] = [];
 
+  // 获取主动技能信息（需在 buffedPlayer 之前，因为 techType 匹配要用）
+  const skillInfo = getActiveSkillInfo(player);
+  const skill = skillInfo?.skill ?? null;
+  const techniqueName = skillInfo?.def.name ?? '';
+  const aptitudeBonus = skillInfo ? calcAptitudeBonus(player, skillInfo.def) : 1.0;
+
   // 叠加功法加成
   const techBonus = getActiveTechniqueBonus(player);
+  let extraAtk = 0;
+
+  // T0059 体修武器 physiqueBonusRate 加成
+  const weaponId = player.equipped?.weapon;
+  const weaponDef = weaponId ? getEquipDef(weaponId) : null;
+  const activeTechDef: TechniqueDef | null = skillInfo?.def ?? null;
+  if (weaponDef?.physiqueBonusRate && weaponDef.techType && activeTechDef) {
+    if (weaponDef.techType.includes(activeTechDef.type)) {
+      extraAtk = Math.floor(player.physique * weaponDef.physiqueBonusRate);
+    }
+  }
+
   const buffedPlayer = {
     ...player,
-    atk: player.atk + (techBonus.atk ?? 0),
+    atk: player.atk + (techBonus.atk ?? 0) + extraAtk,
     def: player.def + (techBonus.def ?? 0),
     speed: player.speed + (techBonus.speed ?? 0),
     critRate: player.critRate + (techBonus.critRate ?? 0),
     critDmgMultiplier: player.critDmgMultiplier + (techBonus.critDmgMultiplier ?? 0),
     hp: player.hp,
     maxHp: player.maxHp + (techBonus.hp ?? 0),
+    physiqueDmgReduce: player.physiqueDmgReduce,
   };
-
-  // 获取主动技能信息
-  const skillInfo = getActiveSkillInfo(player);
-  const skill = skillInfo?.skill ?? null;
-  const techniqueName = skillInfo?.def.name ?? '';
-  const aptitudeBonus = skillInfo ? calcAptitudeBonus(player, skillInfo.def) : 1.0;
 
   // 技能状态
   const skillState: SkillState = {
@@ -86,6 +100,9 @@ export function runCombat(player: Player, monster: MonsterDef): CombatResult {
   }
   if (activeArt) {
     logs.push(`✨ 激活神通：【${activeArt.name}】（${ELEMENT_EMOJI[activeArt.element]}${ELEMENT_CN[activeArt.element]}系）`);
+  }
+  if (extraAtk > 0) {
+    logs.push(`💪 体修加持：体魄×${weaponDef!.physiqueBonusRate} = +${extraAtk} 攻击`);
   }
 
   // 先手：speed 高的先攻
@@ -350,10 +367,20 @@ export function runCombat(player: Player, monster: MonsterDef): CombatResult {
       mpUsed: skillState.totalMpUsed + divineSkillState.totalMpUsed,
       skillUseCount: skillState.useCount,
       snapshots, monsterMaxHp: monster.hp, playerMaxHp: buffedPlayer.maxHp, playerMaxMp: player.mp,
+      bodyExpGained: 0,
     };
   }
 
   const playerWon = pHp > 0;
+
+  // T0059 体修修为战斗结算（胜利+装备体修武器时获得）
+  let bodyExpGained = 0;
+  if (playerWon && weaponDef?.techType) {
+    const hasFistOrFinger = weaponDef.techType.some(t => t === 'fist' || t === 'finger');
+    if (hasFistOrFinger) {
+      bodyExpGained = Math.floor(monster.realmIndex * 10 + 10);
+    }
+  }
 
   if (playerWon) {
     logs.push(`🎉 你击败了 ${monster.name}！`);
@@ -363,6 +390,9 @@ export function runCombat(player: Player, monster: MonsterDef): CombatResult {
     }
     if (divineSkillState.useCount > 0) {
       logs.push(`✨ 本场施展神通 ${divineSkillState.useCount} 次，消耗灵力 ${divineSkillState.totalMpUsed} 点。`);
+    }
+    if (bodyExpGained > 0) {
+      logs.push(`💪 获得体修修为 +${bodyExpGained}`);
     }
   } else {
     logs.push(`💀 你被 ${monster.name} 击败了…`);
@@ -381,5 +411,6 @@ export function runCombat(player: Player, monster: MonsterDef): CombatResult {
     monsterMaxHp: monster.hp,
     playerMaxHp: buffedPlayer.maxHp,
     playerMaxMp: player.mp,
+    bodyExpGained,
   };
 }

--- a/src/game/combat/types.ts
+++ b/src/game/combat/types.ts
@@ -13,6 +13,7 @@ export interface Combatant {
   critRate: number;
   critDmgMultiplier?: number;
   critResist: number;
+  physiqueDmgReduce?: number;     // T0059 体魄减伤（%）
 }
 
 export interface DamageResult {
@@ -58,4 +59,5 @@ export interface CombatResult {
   monsterMaxHp: number;             // 怪物最大 HP（用于血条百分比）
   playerMaxHp: number;              // 玩家最大 HP（含功法加成）
   playerMaxMp: number;              // 玩家最大 MP（战斗开始时）
+  bodyExpGained: number;            // T0059 本场获得的体修修为
 }

--- a/src/game/events.ts
+++ b/src/game/events.ts
@@ -12,6 +12,7 @@ import type { JsonEvent } from './event-loader';
 import type { JsonItem } from './item-loader';
 import { CORE_BREAKTHROUGH_REQS, CORE_TRIBULATIONS } from '../data/core-breakthrough';
 import { CORE_DIVINE_ARTS } from '../data/core-divine-arts';
+import { CORE_BODY_REALMS, CORE_SPIRIT_ROOT_BODY_BONUSES } from '../data/core-body-config';
 import { registerShopGoods } from './shop';
 import type { ShopGoodsDef } from './shop';
 import { getDeathSystemState } from './death';
@@ -276,6 +277,8 @@ export async function registerCoreEvents(): Promise<void> {
     monsters: CORE_MONSTERS,
     divineArts: CORE_DIVINE_ARTS,
     achievements: CORE_ACHIEVEMENTS,
+    bodyRealms: CORE_BODY_REALMS,
+    spiritRootBodyBonuses: CORE_SPIRIT_ROOT_BODY_BONUSES,
   });
   registerShopGoods(coreShopJson as ShopGoodsDef[]);
 }

--- a/src/game/player/create.ts
+++ b/src/game/player/create.ts
@@ -150,6 +150,9 @@ export function createPlayer(options: CreatePlayerOptions): Player {
     items: {}, passives: {}, systems: {},
     tracking: { killCount: 0, bossKillCount: 0, consecutiveRests: 0, consecutiveCultivates: 0, hasBeenBelow10Hp: false, defeatedHigherRealm: false, lowMoodStreak: 0, consecutiveBreakthroughFails: 0 },
     gameYear: 1, gameMonth: 1,
+    // T0059 体修
+    physique: 0, maxPhysique: 50, bodyRealmIndex: 0, bodyRealmExp: 0,
+    physiqueDmgReduce: 0, bodyTempering: 0,
   };
 }
 

--- a/src/game/player/stats.ts
+++ b/src/game/player/stats.ts
@@ -6,6 +6,7 @@ import { REALMS } from '../data';
 import { getEquipDef } from '../registry';
 import { getAllTechniquePassiveBonus } from '../technique';
 import { getAchievementRecalcBonus } from '../achievement/engine';
+import { getBodyRealmBonus } from '../body-cultivation';
 import type { EquipStatBonus } from '../registry';
 import type { Player, Aptitudes, SpiritRootGrade, PlayerSpiritRoots } from './types';
 import type { SpiritRootCombo } from '../spirit-root';
@@ -71,6 +72,9 @@ export function recalcStats(player: Player): Player {
         if (s.critRate) p.critRate += s.critRate;
         if (s.critResist) p.critResist += s.critResist;
         if (s.moveSpeed) p.moveSpeed += s.moveSpeed;
+        // T0059 体修装备加成
+        if (s.physique) p.maxPhysique += s.physique;
+        if (s.physiqueDmgReduce) p.physiqueDmgReduce = Math.min(50, p.physiqueDmgReduce + s.physiqueDmgReduce);
       }
     }
   }
@@ -84,6 +88,9 @@ export function recalcStats(player: Player): Player {
   if (passiveBonus.mp)                p.maxMp += passiveBonus.mp;
   if (passiveBonus.critRate)          p.critRate += passiveBonus.critRate;
   if (passiveBonus.critDmgMultiplier) p.critDmgMultiplier += passiveBonus.critDmgMultiplier;
+  // T0059 功法被动体修加成
+  if (passiveBonus.physique)          p.maxPhysique += passiveBonus.physique;
+  if (passiveBonus.physiqueDmgReduce) p.physiqueDmgReduce = Math.min(50, p.physiqueDmgReduce + passiveBonus.physiqueDmgReduce);
 
   // 成就永久加成（T0031）——recalcStats 型
   const achBonus = getAchievementRecalcBonus(p);
@@ -98,10 +105,19 @@ export function recalcStats(player: Player): Player {
   if (achBonus.critResist)        p.critResist += achBonus.critResist;
   if (achBonus.moveSpeed)         p.moveSpeed += achBonus.moveSpeed;
 
+  // T0059 体修境界加成（从注册表读取）
+  const bodyBonus = getBodyRealmBonus(p);
+  p.maxHp += bodyBonus.hp;
+  p.atk += bodyBonus.atk;
+  p.def += bodyBonus.def;
+  p.maxPhysique = bodyBonus.maxPhysique + (passiveBonus.physique ?? 0);
+  p.physiqueDmgReduce = Math.min(50, bodyBonus.physiqueDmgReduce + (passiveBonus.physiqueDmgReduce ?? 0));
+
   p.hp = Math.min(p.hp, p.maxHp);
   p.mp = Math.min(p.mp, p.maxMp);
   p.stamina = Math.min(p.stamina, p.maxStamina);
   p.mentalPower = Math.min(p.mentalPower, p.maxMentalPower);
+  p.physique = Math.min(p.physique, p.maxPhysique);
   return p;
 }
 

--- a/src/game/player/types.ts
+++ b/src/game/player/types.ts
@@ -93,6 +93,13 @@ export interface Player {
   spiritRoots: PlayerSpiritRoots;          // T0056 五行灵根
   gender: 'male' | 'female';              // T0056 性别
   appearance: number;                      // T0056 外貌（头像序号）
+  // ─── T0059 体修专属属性 ───
+  physique: number;                        // 当前体魄值
+  maxPhysique: number;                     // 体魄上限（由体修境界+功法被动叠加）
+  bodyRealmIndex: number;                  // 体修境界索引（0=凡躯，1-6）
+  bodyRealmExp: number;                    // 当前体修修为
+  physiqueDmgReduce: number;               // 体魄减伤%（上限50）
+  bodyTempering: number;                   // 淬体次数
 }
 
 export interface SpiritRootGrade {

--- a/src/game/registry/dlc.ts
+++ b/src/game/registry/dlc.ts
@@ -8,6 +8,7 @@ import {
   equipRegistry, smithingRecipeRegistry, breakthroughReqRegistry, tribulationRegistry,
   techniqueRegistry, deathTriggerRegistry, lifeSaverRegistry, revivalRegistry,
   monsterRegistry, divineArtRegistry, achievementRegistry,
+  bodyRealmRegistry, spiritRootBodyBonusRegistry,
 } from './stores';
 
 export function registerDLC(pack: DLCPack): void {
@@ -26,6 +27,8 @@ export function registerDLC(pack: DLCPack): void {
   if (pack.monsters) for (const m of pack.monsters) monsterRegistry.set(m.id, m);
   if (pack.divineArts) for (const da of pack.divineArts) divineArtRegistry.set(da.id, da);
   if (pack.achievements) for (const ach of pack.achievements) achievementRegistry.set(ach.id, ach);
+  if (pack.bodyRealms) for (const br of pack.bodyRealms) bodyRealmRegistry.set(br.index, br);
+  if (pack.spiritRootBodyBonuses) for (const sb of pack.spiritRootBodyBonuses) spiritRootBodyBonusRegistry.set(sb.rootType, sb);
 }
 
 export function unregisterDLC(packId: string): void {
@@ -45,6 +48,8 @@ export function unregisterDLC(packId: string): void {
   if (pack.monsters) for (const m of pack.monsters) monsterRegistry.delete(m.id);
   if (pack.divineArts) for (const da of pack.divineArts) divineArtRegistry.delete(da.id);
   if (pack.achievements) for (const ach of pack.achievements) achievementRegistry.delete(ach.id);
+  if (pack.bodyRealms) for (const br of pack.bodyRealms) bodyRealmRegistry.delete(br.index);
+  if (pack.spiritRootBodyBonuses) for (const sb of pack.spiritRootBodyBonuses) spiritRootBodyBonusRegistry.delete(sb.rootType);
   dlcRegistry.delete(packId);
 }
 

--- a/src/game/registry/index.ts
+++ b/src/game/registry/index.ts
@@ -15,6 +15,7 @@ export type {
   DeathSeverity, DeathTriggerDef, DeathPenaltyDef, LifeSaverDef, RevivalMethodDef, DeathSystemState,
   MonsterDef,
   ElementType, DivineArtDef, DivineArtSkillEffect,
+  BodyRealmDef, SpiritRootBodyBonus,
 } from '../types';
 export type {
   AchievementCategory, AchievementDef, AchievementBonusStats,

--- a/src/game/registry/queries.ts
+++ b/src/game/registry/queries.ts
@@ -2,13 +2,15 @@
 // registry/queries.ts — 注册表查询 API
 // ============================================================
 
-import type { ItemCategory, GameEvent, EventCategory, MonsterDef, ElementType, DivineArtDef } from '../types';
+import type { ItemCategory, GameEvent, EventCategory, MonsterDef, ElementType, DivineArtDef, BodyRealmDef, SpiritRootBodyBonus } from '../types';
+import type { SpiritRootType } from '../spirit-root';
 import type { AchievementDef } from '../achievement/types';
 import {
   eventRegistry, itemDefRegistry, recipeRegistry,
   equipRegistry, smithingRecipeRegistry, breakthroughReqRegistry, tribulationRegistry,
   techniqueRegistry, deathTriggerRegistry, lifeSaverRegistry, revivalRegistry,
   monsterRegistry, divineArtRegistry, achievementRegistry,
+  bodyRealmRegistry, spiritRootBodyBonusRegistry,
 } from './stores';
 
 // ── 事件 ──
@@ -82,3 +84,13 @@ export function getDivineArtsByElement(element: ElementType): DivineArtDef[] {
 
 export function getAchievement(id: string): AchievementDef | undefined { return achievementRegistry.get(id); }
 export function getAllAchievementDefs(): AchievementDef[] { return Array.from(achievementRegistry.values()); }
+
+// ── 体修境界（T0059）──
+
+export function getBodyRealmDef(index: number): BodyRealmDef | undefined { return bodyRealmRegistry.get(index); }
+export function getAllBodyRealmDefs(): BodyRealmDef[] { return Array.from(bodyRealmRegistry.values()).sort((a, b) => a.index - b.index); }
+
+// ── 灵根体修加成（T0059）──
+
+export function getSpiritRootBodyBonus(rootType: SpiritRootType): SpiritRootBodyBonus | undefined { return spiritRootBodyBonusRegistry.get(rootType); }
+export function getAllSpiritRootBodyBonuses(): SpiritRootBodyBonus[] { return Array.from(spiritRootBodyBonusRegistry.values()); }

--- a/src/game/registry/stores.ts
+++ b/src/game/registry/stores.ts
@@ -6,6 +6,7 @@ import type {
   GameEvent, ItemDef, RecipeDef, EquipDef,
   SmithingRecipeDef, BreakthroughReqDef, TribulationDef, DLCPack, TechniqueDef,
   DeathTriggerDef, LifeSaverDef, RevivalMethodDef, MonsterDef, DivineArtDef,
+  BodyRealmDef, SpiritRootBodyBonus,
 } from '../types';
 import type { AchievementDef } from '../achievement/types';
 
@@ -24,5 +25,7 @@ export const revivalRegistry = new Map<string, RevivalMethodDef>();
 export const monsterRegistry = new Map<string, MonsterDef>();
 export const divineArtRegistry = new Map<string, DivineArtDef>();
 export const achievementRegistry = new Map<string, AchievementDef>();
+export const bodyRealmRegistry = new Map<number, BodyRealmDef>();
+export const spiritRootBodyBonusRegistry = new Map<string, SpiritRootBodyBonus>();
 export const triggeredOnce = new Set<string>();
 export const cooldowns = new Map<string, number>();

--- a/src/game/technique.ts
+++ b/src/game/technique.ts
@@ -7,6 +7,7 @@ import type { Player } from './player';
 import type { TechniqueDef, TechniqueStatBonus, TechniqueActiveSkill } from './types';
 import type { TechniqueSlot } from './player/types';
 import { getTechniqueDef, getAllTechniqueDefs } from './registry';
+import { gainBodyRealmExp } from './body-cultivation';
 
 // ── 功法类型 → 资质字段映射 ──
 const TYPE_APTITUDE_MAP: Record<string, keyof Player['aptitudes']> = {
@@ -149,10 +150,23 @@ export function practiceTechnique(player: Player, techniqueId: string): { player
 
   const newTechniques = [...p.techniques];
   newTechniques[idx] = { ...slot, level: newLevel, exp: newExp };
+  p = { ...p, techniques: newTechniques };
+
+  // T0059 体修修为（每条功法数据定义自己的 bodyExpRate，0 表示不给体修修为）
+  let bodyExpMsg = '';
+  if (def.bodyExpRate && def.bodyExpRate > 0) {
+    const baseBodyExp = Math.floor(gain * def.bodyExpRate);
+    const { player: p2, message: btMsg, actualGain } = gainBodyRealmExp(p, baseBodyExp);
+    p = p2;
+    if (actualGain > 0) {
+      bodyExpMsg = ` 💪体修修为+${actualGain}`;
+    }
+    if (btMsg) bodyExpMsg += ` ${btMsg}`;
+  }
 
   return {
-    player: { ...p, techniques: newTechniques },
-    message: `🧘 修炼 ${def.name}，熟练度 +${gain}（精力-${staminaCost} 灵力-${mpCost}）。${levelUpMsg}${passiveUnlockMsg}`,
+    player: p,
+    message: `🧘 修炼 ${def.name}，熟练度 +${gain}（精力-${staminaCost} 灵力-${mpCost}）。${levelUpMsg}${passiveUnlockMsg}${bodyExpMsg}`,
   };
 }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -89,6 +89,9 @@ export interface EquipStatBonus {
   critRate?: number;
   critResist?: number;
   moveSpeed?: number;
+  // ─── T0059 体修装备加成 ───
+  physique?: number;              // 装备提供的体魄上限加成
+  physiqueDmgReduce?: number;     // 装备提供的减伤%
 }
 
 export interface EquipDef {
@@ -100,6 +103,9 @@ export interface EquipDef {
   stats: EquipStatBonus;                   // 属性加成
   minRealm: number;                        // 最低佩戴境界
   sellPrice: number;                       // 售卖价格
+  // ─── T0059 体修武器 ───
+  techType?: TechniqueType[];              // 武器兼容的功法类型
+  physiqueBonusRate?: number;              // 体魄值按此比例追加攻击
 }
 
 export interface RecipeDef {
@@ -200,6 +206,10 @@ export interface TechniqueStatBonus {
   critDmgMultiplier?: number;
   hp?: number;
   mp?: number;
+  // ─── T0059 体修被动加成 ───
+  physique?: number;              // 提升体魄上限
+  bodyRealmExp?: number;          // 每次修炼额外获得的体修修为
+  physiqueDmgReduce?: number;     // 额外减伤%（累加，总上限 50%）
 }
 
 /** 功法主动技能定义 */
@@ -242,6 +252,7 @@ export interface TechniqueDef {
   passiveEffects?: PassiveEffect[];        // 多级被动效果，按 minLevel 升序排列（T0019）
   spiritRootElement?: import('./spirit-root').SpiritRootType; // 功法五行属性（T0056）：对应灵根亲和度越高修炼越快、上限越高
   requiredSpiritRoot?: import('./spirit-root').SpiritRootType; // 学习门槛（T0056）：必须拥有此灵根才能习得
+  bodyExpRate?: number;                     // T0059 体修修为系数（0-1，修炼此功法时按此比例给予体修修为）
 }
 
 // ── 事件类型定义 ──
@@ -283,6 +294,30 @@ export interface MonsterDef {
   elementResists?: Partial<Record<ElementType, number>>; // 各系元素抗性 0~1（减免比例）
 }
 
+// ── 体修境界定义（T0059）──
+
+export interface BodyRealmDef {
+  id: string;                     // 'core:body_mortal'
+  name: string;                   // '凡躯' | '铜皮' | …
+  index: number;                  // 0–6
+  maxPhysique: number;            // 该境界体魄上限
+  expReq: number;                 // 升阶所需体修修为
+  physiqueDmgReduce: number;      // 提供的减伤百分比
+  hpBonus: number;                // 额外 HP 加成
+  atkBonus: number;               // 额外攻击加成
+  defBonus: number;               // 额外防御加成
+  description: string;
+}
+
+/** 灵根对体修的加成配置（数据驱动，通过 DLC 注册） */
+export interface SpiritRootBodyBonus {
+  rootType: import('./spirit-root').SpiritRootType;
+  bodyExpMultiplier?: number;     // 体修修为获取倍率（1.3 = +30%）
+  physiqueRegenRate?: number;     // 体魄恢复速率倍率（1.2 = +20%）
+  dmgReduceBonus?: number;        // 额外减伤%
+  hpBonusRate?: number;           // HP 加成比例（0.15 = +15%）
+}
+
 // ── DLC 包定义 ──
 
 // 预留，Phase 1 不实现
@@ -307,6 +342,8 @@ export interface DLCPack {
   monsters?: MonsterDef[];                 // 该 DLC 提供的妖兽定义
   divineArts?: DivineArtDef[];             // 该 DLC 提供的神通定义
   achievements?: import('./achievement/types').AchievementDef[]; // 该 DLC 提供的成就定义
+  bodyRealms?: BodyRealmDef[];              // T0059 体修境界定义
+  spiritRootBodyBonuses?: SpiritRootBodyBonus[]; // T0059 灵根对体修的加成配置
 }
 
 // ── 死亡系统类型定义 ──

--- a/src/hooks/useCoreActions.ts
+++ b/src/hooks/useCoreActions.ts
@@ -13,6 +13,7 @@ import { triggerExploreEvent } from '../game/events';
 import { addItem } from '../game/inventory';
 import { getItemDef, getAllMonsters } from '../game/registry';
 import { checkDeathTriggers, applyDeath, getDeathSystemState } from '../game/death';
+import { restorePhysique, gainBodyRealmExp } from '../game/body-cultivation';
 import type { DeathTriggerDef, DeathSeverity, RevivalMethodDef } from '../game/types';
 import type { LogCategory } from './useGameLog';
 
@@ -131,6 +132,12 @@ export function useCoreActions(deps: CoreActionDeps) {
       p.hp = result.playerHpLeft;
       p.exp += result.expGained;
       p.gold += result.goldGained;
+
+      // T0059 体修修为战斗结算
+      if (result.bodyExpGained > 0) {
+        const { player: p2 } = gainBodyRealmExp(p, result.bodyExpGained);
+        p = p2;
+      }
 
       // 扣减战斗中消耗的灵力
       if (result.mpUsed > 0) {
@@ -296,6 +303,8 @@ export function useCoreActions(deps: CoreActionDeps) {
       p.mp = p.maxMp;
       p.health = Math.min(100, p.health + 5);
       p.mood = Math.min(100, p.mood + 3);
+      // T0059 休息恢复体魄
+      p = restorePhysique(p);
       p.tracking = { ...p.tracking, consecutiveRests: p.tracking.consecutiveRests + 1, consecutiveCultivates: 0 };
       p = advanceTime(p, 'rest');
 


### PR DESCRIPTION
## T0059 体修系统核心

### 新增
- Player 6 个体修属性 (physique/maxPhysique/bodyRealmIndex/bodyRealmExp/physiqueDmgReduce/bodyTempering)
- 7 阶体修境界（凡躯→铜皮→铁骨→玉髓→金刚→龙象→不灭）
- 所有功法按 bodyExpRate 系数给体修修为（fist=1.0 → sword=0.2）
- 五行灵根影响体修效率（金+30%修为, 火+20%, 土+减伤+恢复, 水+HP+恢复, 木+HP）
- 战斗第 5 层减伤：physiqueDmgReduce（cap 50%）
- 体修武器 techType + physiqueBonusRate 追加攻击

### 架构
- **纯数据驱动**：体修境界/灵根加成/功法系数全部通过 `registerDLC()` 注册
- 调数值只改 `src/data/core-body-config.ts` 和 `core-techniques.json`
- 系统代码零硬编码
- 附带数值调整指南：`docs/specs/T0059-body-tuning-guide.md`

### 改动文件
18 files, +1047 -111