### PR TITLE
feat(T0058): 境界表 DLC 化 — 气修境界注册表

### DIFF
--- a/docs/specs/T0058-realm-tuning-guide.md
+++ b/docs/specs/T0058-realm-tuning-guide.md
@@ -1,0 +1,141 @@
+# 气修境界数值调整指南（T0058）
+
+> 本文档面向 @Content / @PM / 未来 Agent，说明如何**只改数据文件**来调整气修境界数值或通过 DLC 追加新境界。
+
+---
+
+## 架构概览
+
+```
+数据层（改这里）                    系统层（不要动）
+─────────────────                ─────────────────
+src/data/core-realms.ts          src/game/data.ts（REALMS 自动从注册表读）
+  └─ CORE_REALMS                 src/game/player/stats.ts（recalcStats）
+                                 src/game/breakthrough/
+                                 所有 REALMS[index] 调用自动生效
+```
+
+所有境界通过 `registerDLC({ realms: [...] })` 注册到 `realmRegistry`。
+旧代码中的 `REALMS[index]` 通过 Proxy 自动从注册表读取，无需修改。
+
+---
+
+## 1. 调整现有境界数值
+
+**文件**：`src/data/core-realms.ts` → `CORE_REALMS` 数组
+
+每个境界是一个 `RealmDef` 对象：
+
+```typescript
+{
+  id: 'core:realm_golden_core',   // 唯一 ID（命名空间:名称）
+  name: '金丹',                   // 显示名称（中文）
+  index: 3,                       // 境界索引（从 0 开始，必须连续）
+  expReq: 2000,                   // 突破到此境界所需修为
+  lifespanBonus: 200,             // 达到此境界后寿命增加
+  hpBase: 1200,                   // 基础 HP
+  mpBase: 400,                    // 基础 MP（灵力）
+  atkBase: 80,                    // 基础攻击
+  defBase: 45,                    // 基础防御
+  speedBase: 25,                  // 基础速度
+  mentalBase: 150,                // 基础念力
+}
+```
+
+### 当前 8 阶数值总览
+
+| Index | 名称 | 修为要求 | 寿命+ | HP | MP | ATK | DEF | 速度 | 念力 |
+|-------|------|---------|-------|-----|------|-----|-----|------|------|
+| 0 | 凡人 | 0 | 0 | 100 | 30 | 8 | 3 | 8 | 20 |
+| 1 | 炼气 | 100 | 50 | 200 | 60 | 15 | 8 | 12 | 40 |
+| 2 | 筑基 | 500 | 100 | 500 | 150 | 35 | 20 | 18 | 80 |
+| 3 | 金丹 | 2000 | 200 | 1200 | 400 | 80 | 45 | 25 | 150 |
+| 4 | 元婴 | 8000 | 500 | 3000 | 1000 | 180 | 100 | 35 | 300 |
+| 5 | 化神 | 30000 | 1000 | 7000 | 2500 | 400 | 220 | 50 | 600 |
+| 6 | 渡劫 | 100000 | 2000 | 15000 | 5000 | 900 | 500 | 70 | 1200 |
+| 7 | 大乘 | 500000 | 5000 | 35000 | 12000 | 2000 | 1100 | 100 | 2500 |
+
+### 调整示例
+
+**想让金丹更强**：改 `index: 3` 那条的数字即可。
+
+**想降低炼气突破门槛**：把 `index: 1` 的 `expReq` 从 `100` 改为 `50`。
+
+---
+
+## 2. DLC 追加新境界（飞升）
+
+在 DLC 数据文件中追加 `index: 8+` 的境界，通过 `registerDLC()` 注册即可：
+
+```typescript
+// 未来的飞升 DLC 示例
+import type { RealmDef } from '../game/types';
+
+export const ASCENSION_REALMS: RealmDef[] = [
+  { id: 'asc:loose_immortal', name: '散仙', index: 8,  expReq: 1000000,  lifespanBonus: 10000, hpBase: 80000,  mpBase: 25000, atkBase: 4500,  defBase: 2500, speedBase: 140, mentalBase: 5000 },
+  { id: 'asc:earth_immortal', name: '地仙', index: 9,  expReq: 3000000,  lifespanBonus: 50000, hpBase: 200000, mpBase: 60000, atkBase: 10000, defBase: 5500, speedBase: 200, mentalBase: 10000 },
+  { id: 'asc:sky_immortal',   name: '天仙', index: 10, expReq: 10000000, lifespanBonus: Infinity, hpBase: 500000, mpBase: 150000, atkBase: 25000, defBase: 13000, speedBase: 300, mentalBase: 25000 },
+  { id: 'asc:golden_immortal', name: '金仙', index: 11, expReq: 50000000, lifespanBonus: Infinity, hpBase: 1200000, mpBase: 400000, atkBase: 60000, defBase: 30000, speedBase: 500, mentalBase: 60000 },
+];
+
+// 在 DLC 注册时：
+registerDLC({
+  id: 'expansion-ascension',
+  name: '仙道飞升',
+  version: '1.0.0',
+  description: '大乘之后的四阶仙道境界',
+  realms: ASCENSION_REALMS,
+  // 配套的突破需求、天劫、妖兽等
+  breakthroughReqs: [...],
+  tribulations: [...],
+  monsters: [...],
+});
+```
+
+注册后：
+- `REALMS[8]` 自动返回散仙
+- `getNextRealm(player)` 在大乘期会返回散仙
+- 突破系统自动支持新境界（需配套 `breakthroughReqs`）
+- 所有 UI 自动显示新境界名称
+
+---
+
+## 3. 系统如何使用境界数据
+
+| 使用方 | 访问方式 | 说明 |
+|--------|---------|------|
+| `recalcStats()` | `REALMS[player.realmIndex]` | 读 hpBase/mpBase/atkBase 等基础属性 |
+| `getNextRealm()` | `REALMS[realmIndex + 1]` | 判断下一个境界是否存在 |
+| `breakthrough` | `REALMS[newIndex]` | 突破后读取新境界属性 |
+| UI 组件 | `REALMS[realmIndex].name` | 显示境界名称 |
+| `createPlayer()` | `REALMS[0]` | 初始化角色为凡人境界 |
+| 死亡/渡劫 | `REALMS[realmIndex]` | 境界跌落时读取名称 |
+
+所有这些都通过 Proxy 自动从注册表读取，**DLC 追加的境界自动生效**。
+
+---
+
+## 4. 快速检查清单
+
+改完数值后确认以下几点：
+
+- [ ] `index` 是否从 0 开始、连续递增（不能跳号）
+- [ ] `expReq` 是否严格递增（低阶 < 高阶）
+- [ ] 每个 `id` 是否唯一（命名空间:名称 格式）
+- [ ] 数值增长是否合理（建议每阶 2-3 倍递增）
+- [ ] DLC 新境界的 `index` 是否从核心包最大 index + 1 开始
+- [ ] 若追加新境界，是否配套了 `breakthroughReqs` 和 `tribulations`
+- [ ] 运行 `npx tsc --noEmit` 确认无语法错误
+
+---
+
+## 5. 与 T0059 体修系统的关系
+
+气修境界（本文档）和体修境界（T0059）是**独立的两套注册表**：
+
+| 系统 | 数据文件 | 注册表 | 字段 |
+|------|---------|--------|------|
+| 气修 | `src/data/core-realms.ts` | `realmRegistry` | `player.realmIndex` |
+| 体修 | `src/data/core-body-config.ts` | `bodyRealmRegistry` | `player.bodyRealmIndex` |
+
+两者互不影响，DLC 可以分别扩展。

--- a/src/data/core-realms.ts
+++ b/src/data/core-realms.ts
@@ -1,0 +1,19 @@
+// ============================================================
+// data/core-realms.ts — 气修境界定义（T0058）
+// 8 阶核心境界通过 registerDLC() 注册。
+// 调数值只改此文件，不需要动系统代码。
+// DLC 可追加更高境界（如散仙→金仙），index 从 8 开始。
+// ============================================================
+
+import type { RealmDef } from '../game/types';
+
+export const CORE_REALMS: RealmDef[] = [
+  { id: 'core:realm_mortal',        name: '凡人', index: 0, expReq: 0,      lifespanBonus: 0,    hpBase: 100,   mpBase: 30,    atkBase: 8,    defBase: 3,    speedBase: 8,   mentalBase: 20   },
+  { id: 'core:realm_qi_refining',   name: '炼气', index: 1, expReq: 100,    lifespanBonus: 50,   hpBase: 200,   mpBase: 60,    atkBase: 15,   defBase: 8,    speedBase: 12,  mentalBase: 40   },
+  { id: 'core:realm_foundation',    name: '筑基', index: 2, expReq: 500,    lifespanBonus: 100,  hpBase: 500,   mpBase: 150,   atkBase: 35,   defBase: 20,   speedBase: 18,  mentalBase: 80   },
+  { id: 'core:realm_golden_core',   name: '金丹', index: 3, expReq: 2000,   lifespanBonus: 200,  hpBase: 1200,  mpBase: 400,   atkBase: 80,   defBase: 45,   speedBase: 25,  mentalBase: 150  },
+  { id: 'core:realm_nascent_soul',  name: '元婴', index: 4, expReq: 8000,   lifespanBonus: 500,  hpBase: 3000,  mpBase: 1000,  atkBase: 180,  defBase: 100,  speedBase: 35,  mentalBase: 300  },
+  { id: 'core:realm_deity_trans',   name: '化神', index: 5, expReq: 30000,  lifespanBonus: 1000, hpBase: 7000,  mpBase: 2500,  atkBase: 400,  defBase: 220,  speedBase: 50,  mentalBase: 600  },
+  { id: 'core:realm_tribulation',   name: '渡劫', index: 6, expReq: 100000, lifespanBonus: 2000, hpBase: 15000, mpBase: 5000,  atkBase: 900,  defBase: 500,  speedBase: 70,  mentalBase: 1200 },
+  { id: 'core:realm_mahayana',      name: '大乘', index: 7, expReq: 500000, lifespanBonus: 5000, hpBase: 35000, mpBase: 12000, atkBase: 2000, defBase: 1100, speedBase: 100, mentalBase: 2500 },
+];

--- a/src/game/breakthrough/status.ts
+++ b/src/game/breakthrough/status.ts
@@ -4,7 +4,8 @@
 
 import type { Player } from '../player';
 import { getNextRealm } from '../player';
-import { REALMS, BREAKTHROUGH_BASE_RATE, BREAKTHROUGH_COMP_BONUS, BREAKTHROUGH_LUCK_BONUS } from '../data';
+import { BREAKTHROUGH_BASE_RATE, BREAKTHROUGH_COMP_BONUS, BREAKTHROUGH_LUCK_BONUS } from '../data';
+import type { Realm } from '../data';
 import { getBreakthroughReq, getItemDef } from '../registry';
 import type { BreakthroughReqDef } from '../registry';
 
@@ -13,7 +14,7 @@ export interface CondCheckResult { id: string; description: string; ready: boole
 
 export interface BreakthroughStatus {
   canAttempt: boolean;
-  nextRealm: typeof REALMS[number] | null;
+  nextRealm: Realm | null;
   req: BreakthroughReqDef | null;
   expReady: boolean;
   itemsReady: ItemCheckResult[];

--- a/src/game/data.ts
+++ b/src/game/data.ts
@@ -4,18 +4,12 @@
 // ============================================================
 
 // ── 类型定义 ──
-export interface Realm {
-  name: string;
-  index: number;
-  expReq: number;
-  lifespanBonus: number;
-  hpBase: number;
-  mpBase: number;
-  atkBase: number;
-  defBase: number;
-  speedBase: number;
-  mentalBase: number;
-}
+
+// T0058: Realm 保留为向后兼容别名，实际类型为 RealmDef（定义在 types.ts）
+import type { RealmDef } from './types';
+export type Realm = RealmDef;
+
+import { getAllRealmDefs, getRealmDef } from './registry/queries';
 
 export interface ActionCost {
   stamina: number;
@@ -41,18 +35,40 @@ export interface Pill {
   desc: string;
 }
 
-// ── 境界表 ──
-// index 对应 realmIndex，属性值为该境界的基础数值
-export const REALMS: Realm[] = [
-  { name: '凡人',   index: 0,  expReq: 0,      lifespanBonus: 0,     hpBase: 100,  mpBase: 30,   atkBase: 8,   defBase: 3,   speedBase: 8,   mentalBase: 20  },
-  { name: '炼气',   index: 1,  expReq: 100,    lifespanBonus: 50,    hpBase: 200,  mpBase: 60,   atkBase: 15,  defBase: 8,   speedBase: 12,  mentalBase: 40  },
-  { name: '筑基',   index: 2,  expReq: 500,    lifespanBonus: 100,   hpBase: 500,  mpBase: 150,  atkBase: 35,  defBase: 20,  speedBase: 18,  mentalBase: 80  },
-  { name: '金丹',   index: 3,  expReq: 2000,   lifespanBonus: 200,   hpBase: 1200, mpBase: 400,  atkBase: 80,  defBase: 45,  speedBase: 25,  mentalBase: 150 },
-  { name: '元婴',   index: 4,  expReq: 8000,   lifespanBonus: 500,   hpBase: 3000, mpBase: 1000, atkBase: 180, defBase: 100, speedBase: 35,  mentalBase: 300 },
-  { name: '化神',   index: 5,  expReq: 30000,  lifespanBonus: 1000,  hpBase: 7000, mpBase: 2500, atkBase: 400, defBase: 220, speedBase: 50,  mentalBase: 600 },
-  { name: '渡劫',   index: 6,  expReq: 100000, lifespanBonus: 2000,  hpBase: 15000,mpBase: 5000, atkBase: 900, defBase: 500, speedBase: 70,  mentalBase: 1200},
-  { name: '大乘',   index: 7,  expReq: 500000, lifespanBonus: 5000,  hpBase: 35000,mpBase: 12000,atkBase: 2000,defBase: 1100,speedBase: 100, mentalBase: 2500},
-];
+// ── 境界表（T0058: DLC 化，从注册表动态读取）──
+// 核心境界数据在 src/data/core-realms.ts，通过 registerDLC() 注册。
+// REALMS 保留为向后兼容的访问器，所有旧代码 REALMS[index] 照常工作。
+// DLC 追加新境界后，REALMS 会自动包含新境界。
+
+/** @deprecated 直接使用 getRealmDef(index) 或 getAllRealmDefs() 代替 */
+export function getRealms(): RealmDef[] {
+  return getAllRealmDefs();
+}
+
+// 向后兼容：大部分旧代码使用 REALMS[index] 访问
+// 使用 Proxy 让 REALMS 表现为数组但从注册表读数据
+const REALMS_PROXY_HANDLER: ProxyHandler<RealmDef[]> = {
+  get(_, prop) {
+    // 数字索引：从注册表读
+    if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+      return getRealmDef(Number(prop));
+    }
+    // .length
+    if (prop === 'length') {
+      const all = getAllRealmDefs();
+      return all.length > 0 ? all[all.length - 1].index + 1 : 0;
+    }
+    // .map / .filter / .forEach / Symbol.iterator 等数组方法
+    const arr = getAllRealmDefs();
+    const val = (arr as unknown as Record<string | symbol, unknown>)[prop];
+    if (typeof val === 'function') {
+      return (val as Function).bind(arr);
+    }
+    return val;
+  },
+};
+
+export const REALMS = new Proxy([] as RealmDef[], REALMS_PROXY_HANDLER);
 
 // ── 操作消耗 & 时间推进（time 单位：月） ──
 export const ACTION_COSTS: Record<string, ActionCost> = {

--- a/src/game/events.ts
+++ b/src/game/events.ts
@@ -13,6 +13,7 @@ import type { JsonItem } from './item-loader';
 import { CORE_BREAKTHROUGH_REQS, CORE_TRIBULATIONS } from '../data/core-breakthrough';
 import { CORE_DIVINE_ARTS } from '../data/core-divine-arts';
 import { CORE_BODY_REALMS, CORE_SPIRIT_ROOT_BODY_BONUSES } from '../data/core-body-config';
+import { CORE_REALMS } from '../data/core-realms';
 import { registerShopGoods } from './shop';
 import type { ShopGoodsDef } from './shop';
 import { getDeathSystemState } from './death';
@@ -279,6 +280,7 @@ export async function registerCoreEvents(): Promise<void> {
     achievements: CORE_ACHIEVEMENTS,
     bodyRealms: CORE_BODY_REALMS,
     spiritRootBodyBonuses: CORE_SPIRIT_ROOT_BODY_BONUSES,
+    realms: CORE_REALMS,
   });
   registerShopGoods(coreShopJson as ShopGoodsDef[]);
 }

--- a/src/game/registry/dlc.ts
+++ b/src/game/registry/dlc.ts
@@ -8,7 +8,7 @@ import {
   equipRegistry, smithingRecipeRegistry, breakthroughReqRegistry, tribulationRegistry,
   techniqueRegistry, deathTriggerRegistry, lifeSaverRegistry, revivalRegistry,
   monsterRegistry, divineArtRegistry, achievementRegistry,
-  bodyRealmRegistry, spiritRootBodyBonusRegistry,
+  bodyRealmRegistry, spiritRootBodyBonusRegistry, realmRegistry,
 } from './stores';
 
 export function registerDLC(pack: DLCPack): void {
@@ -29,6 +29,7 @@ export function registerDLC(pack: DLCPack): void {
   if (pack.achievements) for (const ach of pack.achievements) achievementRegistry.set(ach.id, ach);
   if (pack.bodyRealms) for (const br of pack.bodyRealms) bodyRealmRegistry.set(br.index, br);
   if (pack.spiritRootBodyBonuses) for (const sb of pack.spiritRootBodyBonuses) spiritRootBodyBonusRegistry.set(sb.rootType, sb);
+  if (pack.realms) for (const r of pack.realms) realmRegistry.set(r.index, r);
 }
 
 export function unregisterDLC(packId: string): void {
@@ -50,6 +51,7 @@ export function unregisterDLC(packId: string): void {
   if (pack.achievements) for (const ach of pack.achievements) achievementRegistry.delete(ach.id);
   if (pack.bodyRealms) for (const br of pack.bodyRealms) bodyRealmRegistry.delete(br.index);
   if (pack.spiritRootBodyBonuses) for (const sb of pack.spiritRootBodyBonuses) spiritRootBodyBonusRegistry.delete(sb.rootType);
+  if (pack.realms) for (const r of pack.realms) realmRegistry.delete(r.index);
   dlcRegistry.delete(packId);
 }
 

--- a/src/game/registry/index.ts
+++ b/src/game/registry/index.ts
@@ -16,6 +16,7 @@ export type {
   MonsterDef,
   ElementType, DivineArtDef, DivineArtSkillEffect,
   BodyRealmDef, SpiritRootBodyBonus,
+  RealmDef,
 } from '../types';
 export type {
   AchievementCategory, AchievementDef, AchievementBonusStats,
@@ -37,6 +38,9 @@ export {
   getMonster, getAllMonsters, getMonstersByRealm,
   getDivineArtDef, getAllDivineArtDefs, getDivineArtsByElement,
   getAchievement, getAllAchievementDefs,
+  getBodyRealmDef, getAllBodyRealmDefs,
+  getSpiritRootBodyBonus, getAllSpiritRootBodyBonuses,
+  getRealmDef, getAllRealmDefs, getMaxRealmIndex,
 } from './queries';
 export {
   triggerEvent, resetRuntimeState, saveEventState, loadEventState,

--- a/src/game/registry/queries.ts
+++ b/src/game/registry/queries.ts
@@ -2,7 +2,7 @@
 // registry/queries.ts — 注册表查询 API
 // ============================================================
 
-import type { ItemCategory, GameEvent, EventCategory, MonsterDef, ElementType, DivineArtDef, BodyRealmDef, SpiritRootBodyBonus } from '../types';
+import type { ItemCategory, GameEvent, EventCategory, MonsterDef, ElementType, DivineArtDef, BodyRealmDef, SpiritRootBodyBonus, RealmDef } from '../types';
 import type { SpiritRootType } from '../spirit-root';
 import type { AchievementDef } from '../achievement/types';
 import {
@@ -10,7 +10,7 @@ import {
   equipRegistry, smithingRecipeRegistry, breakthroughReqRegistry, tribulationRegistry,
   techniqueRegistry, deathTriggerRegistry, lifeSaverRegistry, revivalRegistry,
   monsterRegistry, divineArtRegistry, achievementRegistry,
-  bodyRealmRegistry, spiritRootBodyBonusRegistry,
+  bodyRealmRegistry, spiritRootBodyBonusRegistry, realmRegistry,
 } from './stores';
 
 // ── 事件 ──
@@ -94,3 +94,13 @@ export function getAllBodyRealmDefs(): BodyRealmDef[] { return Array.from(bodyRe
 
 export function getSpiritRootBodyBonus(rootType: SpiritRootType): SpiritRootBodyBonus | undefined { return spiritRootBodyBonusRegistry.get(rootType); }
 export function getAllSpiritRootBodyBonuses(): SpiritRootBodyBonus[] { return Array.from(spiritRootBodyBonusRegistry.values()); }
+
+// ── 气修境界（T0058）──
+
+export function getRealmDef(index: number): RealmDef | undefined { return realmRegistry.get(index); }
+export function getAllRealmDefs(): RealmDef[] { return Array.from(realmRegistry.values()).sort((a, b) => a.index - b.index); }
+export function getMaxRealmIndex(): number {
+  let max = -1;
+  for (const key of realmRegistry.keys()) { if (key > max) max = key; }
+  return max;
+}

--- a/src/game/registry/stores.ts
+++ b/src/game/registry/stores.ts
@@ -6,7 +6,7 @@ import type {
   GameEvent, ItemDef, RecipeDef, EquipDef,
   SmithingRecipeDef, BreakthroughReqDef, TribulationDef, DLCPack, TechniqueDef,
   DeathTriggerDef, LifeSaverDef, RevivalMethodDef, MonsterDef, DivineArtDef,
-  BodyRealmDef, SpiritRootBodyBonus,
+  BodyRealmDef, SpiritRootBodyBonus, RealmDef,
 } from '../types';
 import type { AchievementDef } from '../achievement/types';
 
@@ -27,5 +27,6 @@ export const divineArtRegistry = new Map<string, DivineArtDef>();
 export const achievementRegistry = new Map<string, AchievementDef>();
 export const bodyRealmRegistry = new Map<number, BodyRealmDef>();
 export const spiritRootBodyBonusRegistry = new Map<string, SpiritRootBodyBonus>();
+export const realmRegistry = new Map<number, RealmDef>();
 export const triggeredOnce = new Set<string>();
 export const cooldowns = new Map<string, number>();

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -309,6 +309,22 @@ export interface BodyRealmDef {
   description: string;
 }
 
+// ── 气修境界定义（T0058）──
+
+export interface RealmDef {
+  id: string;                     // 'core:realm_mortal'
+  name: string;                   // '凡人' | '炼气' | …
+  index: number;                  // 0–7+（DLC 可追加更高境界）
+  expReq: number;                 // 突破所需修为
+  lifespanBonus: number;          // 寿命加成
+  hpBase: number;                 // 基础 HP
+  mpBase: number;                 // 基础 MP
+  atkBase: number;                // 基础攻击
+  defBase: number;                // 基础防御
+  speedBase: number;              // 基础速度
+  mentalBase: number;             // 基础念力
+}
+
 /** 灵根对体修的加成配置（数据驱动，通过 DLC 注册） */
 export interface SpiritRootBodyBonus {
   rootType: import('./spirit-root').SpiritRootType;
@@ -344,6 +360,7 @@ export interface DLCPack {
   achievements?: import('./achievement/types').AchievementDef[]; // 该 DLC 提供的成就定义
   bodyRealms?: BodyRealmDef[];              // T0059 体修境界定义
   spiritRootBodyBonuses?: SpiritRootBodyBonus[]; // T0059 灵根对体修的加成配置
+  realms?: RealmDef[];                       // T0058 气修境界定义
 }
 
 // ── 死亡系统类型定义 ──


### PR DESCRIPTION
## T0058 境界表 DLC 化

### 改动
- `RealmDef` 类型 + `realmRegistry` 注册表
- 8 阶核心境界迁移到 `src/data/core-realms.ts`
- `REALMS` 改为 Proxy 自动从注册表读取（向后兼容,旧代码零修改）
- DLC 可追加更高境界 `registerDLC({ realms: [...] })`

### 向后兼容
- `REALMS[0].name` → 照常工作
- `REALMS.map()` → 照常工作
- `typeof REALMS[number]` → 替换为 `Realm` 类型别名

### 后续
- T0033 飞升可通过 DLC 追加 index 8-11（散仙→金仙）
- 附带调整指南：`docs/specs/T0058-realm-tuning-guide.md`

8 files, +243 -30