### PR TITLE
fix: 修复神通无法取消激活

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,7 @@ export default function App() {
           onActivateTechnique={engine.activateTechnique}
           onLearnDivineArt={engine.learnDivineArt}
           onActivateDivineArt={engine.activateDivineArt}
+          onDeactivateDivineArt={engine.deactivateDivineArt}
         />
       }
       debug={<>

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -43,13 +43,14 @@ interface RightPanelProps {
   onActivateTechnique: (techniqueId: string) => void;
   onLearnDivineArt: (artId: string) => void;
   onActivateDivineArt: (artId: string) => void;
+  onDeactivateDivineArt: () => void;
 }
 
 export default function RightPanel({
   player, activePanel, onSelectPanel,
   onUseItem, onCraft, onSmith, onEquip, onUnequip, onBuy, onSell,
   onLearnTechnique, onPracticeTechnique, onActivateTechnique,
-  onLearnDivineArt, onActivateDivineArt,
+  onLearnDivineArt, onActivateDivineArt, onDeactivateDivineArt,
 }: RightPanelProps) {
   const closePanel = () => onSelectPanel(activePanel!);
   const config = activePanel ? PANEL_CONFIG[activePanel] : null;
@@ -68,7 +69,7 @@ export default function RightPanel({
           {activePanel === 'inventory' && <InventoryPanel player={player} onUseItem={onUseItem} />}
           {activePanel === 'shop' && <ShopPanel player={player} onBuy={onBuy} onSell={onSell} />}
           {activePanel === 'technique' && <TechniquePanel player={player} onLearn={onLearnTechnique} onPractice={onPracticeTechnique} onActivate={onActivateTechnique} />}
-          {activePanel === 'divine' && <DivineArtsPanel player={player} onLearn={onLearnDivineArt} onActivate={onActivateDivineArt} />}
+          {activePanel === 'divine' && <DivineArtsPanel player={player} onLearn={onLearnDivineArt} onActivate={onActivateDivineArt} onDeactivate={onDeactivateDivineArt} />}
           {activePanel === 'crafting' && <CraftingPanel player={player} onCraft={onCraft} onSmith={onSmith} />}
           {activePanel === 'equipment' && <EquipmentPanel player={player} onEquip={onEquip} onUnequip={onUnequip} />}
           {activePanel === 'achievement' && <AchievementPanel player={player} />}

--- a/src/components/panels/DivineArtsPanel.tsx
+++ b/src/components/panels/DivineArtsPanel.tsx
@@ -18,9 +18,10 @@ interface DivineArtsPanelProps {
   player: Player;
   onLearn: (artId: string) => void;
   onActivate: (artId: string) => void;
+  onDeactivate: () => void;
 }
 
-export default function DivineArtsPanel({ player, onLearn, onActivate }: DivineArtsPanelProps) {
+export default function DivineArtsPanel({ player, onLearn, onActivate, onDeactivate }: DivineArtsPanelProps) {
   const state = getDivineArtsState(player);
   const learnedIds = new Set(state.learned.map(s => s.artId));
   const allDefs = getAllDivineArtDefs();
@@ -70,6 +71,7 @@ export default function DivineArtsPanel({ player, onLearn, onActivate }: DivineA
                 aptitude={aptitude}
                 canActivate={!isActive}
                 onActivate={() => onActivate(def.id)}
+                onDeactivate={onDeactivate}
               />
             );
           })}
@@ -112,9 +114,10 @@ interface DivineArtCardProps {
   aptitude: number;
   canActivate: boolean;
   onActivate: () => void;
+  onDeactivate: () => void;
 }
 
-function DivineArtCard({ def, isActive, aptitude, canActivate, onActivate }: DivineArtCardProps) {
+function DivineArtCard({ def, isActive, aptitude, canActivate, onActivate, onDeactivate }: DivineArtCardProps) {
   const color = ELEMENT_COLOR[def.element];
   const emoji = ELEMENT_EMOJI[def.element];
   const cn = ELEMENT_CN[def.element];
@@ -160,7 +163,7 @@ function DivineArtCard({ def, isActive, aptitude, canActivate, onActivate }: Div
           </button>
         )}
         {isActive && (
-          <button className="btn btn-technique" onClick={onActivate}>
+          <button className="btn btn-technique" onClick={onDeactivate}>
             ❎ 取消激活
           </button>
         )}

--- a/src/game/divine-arts.ts
+++ b/src/game/divine-arts.ts
@@ -106,6 +106,21 @@ export function activateDivineArt(player: Player, artId: string): { player: Play
   };
 }
 
+/** 取消激活当前神通 */
+export function deactivateDivineArt(player: Player): { player: Player; message: string } {
+  const state = getDivineArtsState(player);
+  if (!state.activeArtId) {
+    return { player, message: '❌ 当前没有激活的神通。' };
+  }
+  const artDef = getDivineArtDef(state.activeArtId);
+  const artName = artDef ? artDef.name : state.activeArtId;
+  const newState: DivineArtsSystemState = { ...state, activeArtId: null };
+  return {
+    player: { ...player, systems: { ...player.systems, divineArts: newState } },
+    message: `❎ 已取消激活神通【${artName}】。`,
+  };
+}
+
 /** 获取可学神通列表：境界达标 + 资质达标 + 未已学 */
 export function getLearnableDivineArts(player: Player): DivineArtDef[] {
   const state = getDivineArtsState(player);

--- a/src/hooks/useGameEngine.ts
+++ b/src/hooks/useGameEngine.ts
@@ -465,7 +465,7 @@ export function useGameEngine(
   const {
     useItem, craft, equip, unequip, buy, sell, smith, breakthrough,
     learnTechnique, practiceTechnique, activateTechnique,
-    learnDivineArt, activateDivineArt,
+    learnDivineArt, activateDivineArt, deactivateDivineArt,
   } = useSystemActions({
     player, addLog, setPlayer, setGameOver, setGameOverReason, setDeathModal,
   });
@@ -523,6 +523,7 @@ export function useGameEngine(
     activateTechnique,
     learnDivineArt,
     activateDivineArt,
+    deactivateDivineArt,
     toast,
     dismissToast,
     combatModal,

--- a/src/hooks/useSystemActions.ts
+++ b/src/hooks/useSystemActions.ts
@@ -13,7 +13,7 @@ import { performSmithing } from '../game/smithing';
 import { attemptBreakthrough as attemptBreakthroughFn } from '../game/breakthrough';
 import { runTribulation as runTribulationFn } from '../game/tribulation';
 import { learnTechnique, practiceTechnique, activateTechnique } from '../game/technique';
-import { learnDivineArt as learnDivineArtFn, activateDivineArt as activateDivineArtFn } from '../game/divine-arts';
+import { learnDivineArt as learnDivineArtFn, activateDivineArt as activateDivineArtFn, deactivateDivineArt as deactivateDivineArtFn } from '../game/divine-arts';
 import { recalcStats } from '../game/player';
 import { checkDeathTriggers, applyDeath, getDeathSystemState } from '../game/death';
 import type { EquipSlot } from '../game/registry';
@@ -132,6 +132,10 @@ export function useSystemActions(deps: SystemActionDeps) {
     execAction(p => activateDivineArtFn(p, artId));
   }, [execAction]);
 
+  const deactivateDivineArt = useCallback(() => {
+    execAction(p => deactivateDivineArtFn(p));
+  }, [execAction]);
+
   return {
     useItem: useItemAction,
     craft,
@@ -146,5 +150,6 @@ export function useSystemActions(deps: SystemActionDeps) {
     activateTechnique: activate,
     learnDivineArt,
     activateDivineArt,
+    deactivateDivineArt,
   };
 }


### PR DESCRIPTION
## Bug

神通激活后点击「取消激活」按钮无效——按钮错误调用了 onActivate，等于重新激活。

## 修复

新增完整的 deactivateDivineArt 链路：
- `divine-arts.ts`: 新增 `deactivateDivineArt()` 函数，将 activeArtId 置为 null
- `useSystemActions.ts`: 新增 deactivate callback
- `useGameEngine.ts`: 透传新方法
- `DivineArtsPanel.tsx`: 取消激活按钮改为调用 onDeactivate
- `RightPanel.tsx` / `App.tsx`: 透传 prop