### PR TITLE
refactor: 拆分 useGameEngine.ts（538→324行）

### DIFF
--- a/src/hooks/useCombatModal.ts
+++ b/src/hooks/useCombatModal.ts
@@ -1,0 +1,150 @@
+// ============================================================
+// useCombatModal.ts — 战斗弹窗状态 + 回调
+// 从 useGameEngine.ts 拆出，管理战斗/死亡弹窗的显示逻辑
+// ============================================================
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { CombatResult } from '../game/combat';
+import type { RoundSnapshot } from '../game/combat/types';
+import type { DeathTriggerDef, DeathSeverity, RevivalMethodDef } from '../game/types';
+import type { LootEntry, CombatDeathInfo } from './useCoreActions';
+import type { Player } from '../game/player';
+import { getDeathSystemState } from '../game/death';
+import type { LogCategory } from './useGameLog';
+
+export interface CombatModalState {
+  phase: 'battle' | 'loot';
+  monsterName: string;
+  monsterEmoji: string;
+  result: CombatResult;
+  loot: LootEntry[];
+  deathInfo?: CombatDeathInfo;
+  playerHpBefore: number;
+  playerMpBefore: number;
+  playerAvatar: string;
+  playerName: string;
+  playerRealmIndex: number;
+  playerMaxHp: number;
+  playerMaxMp: number;
+  monsterMaxHp: number;
+  snapshots: RoundSnapshot[];
+}
+
+export interface DeathModalState {
+  triggerDef: DeathTriggerDef;
+  severity: DeathSeverity;
+  availableRevivals: RevivalMethodDef[];
+  playerSnapshot: {
+    name: string;
+    realmIndex: number;
+    age: number;
+    killCount: number;
+    deathCount: number;
+  };
+}
+
+export function useCombatModal(
+  playerRef: React.RefObject<Player | null>,
+  addLog: (msg: string, category?: LogCategory) => void,
+  setGameOver: (v: boolean) => void,
+  setGameOverReason: (v: string) => void,
+  setDeathModal: (v: DeathModalState | null) => void,
+) {
+  const [combatModal, setCombatModal] = useState<CombatModalState | null>(null);
+  const combatModalRef = useRef<CombatModalState | null>(null);
+  useEffect(() => { combatModalRef.current = combatModal; }, [combatModal]);
+
+  const onCombatResult = useCallback((
+    monsterName: string, monsterEmoji: string, result: CombatResult,
+    loot: LootEntry[], deathInfo?: CombatDeathInfo,
+    hpBefore?: number, mpBefore?: number,
+  ) => {
+    const p = playerRef.current;
+    setCombatModal({
+      phase: 'battle',
+      monsterName,
+      monsterEmoji,
+      result,
+      loot,
+      deathInfo,
+      playerHpBefore: hpBefore ?? 0,
+      playerMpBefore: mpBefore ?? 0,
+      playerAvatar: p?.avatar ?? 'default',
+      playerName: p?.name ?? '',
+      playerRealmIndex: p?.realmIndex ?? 0,
+      playerMaxHp: p?.maxHp ?? 100,
+      playerMaxMp: p?.maxMp ?? 30,
+      monsterMaxHp: result.monsterMaxHp,
+      snapshots: result.snapshots,
+    });
+  }, [playerRef]);
+
+  const handleCombatNext = useCallback(() => {
+    setCombatModal(prev => prev ? { ...prev, phase: 'loot' } : null);
+  }, []);
+
+  const handleCombatClose = useCallback(() => {
+    const modal = combatModalRef.current;
+    if (!modal) return;
+    const { monsterName, result, loot, deathInfo, playerHpBefore, playerMpBefore } = modal;
+
+    if (result.winner === 'player') {
+      const details: string[] = [];
+      if (result.expGained > 0) details.push(`+${result.expGained}修为`);
+      if (result.goldGained > 0) details.push(`+${result.goldGained}灵石`);
+      if (result.bodyExpGained > 0) details.push(`+${result.bodyExpGained}体修`);
+      const hpLost = playerHpBefore - result.playerHpLeft;
+      if (hpLost > 0) details.push(`-${hpLost}HP`);
+      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
+      if (loot.length > 0) details.push(`获得: ${loot.map(l => `${l.name}×${l.amount}`).join(' ')}`);
+      addLog(`⚔️ 击败 ${monsterName}（${details.join(' ')}）`, 'combat');
+    } else if (result.winner === 'monster') {
+      const details: string[] = [];
+      const hpLost = playerHpBefore - result.playerHpLeft;
+      if (hpLost > 0) details.push(`-${hpLost}HP`);
+      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
+      if (result.bodyExpGained > 0) details.push(`+${result.bodyExpGained}体修`);
+      if (deathInfo?.blocked) {
+        details.push(`${deathInfo.saverName ?? '护命道具'}救回一命`);
+      } else if (deathInfo?.triggered && deathInfo.penaltyLogs?.length) {
+        details.push(...deathInfo.penaltyLogs);
+      } else {
+        details.push('-20健康');
+      }
+      addLog(`💀 败于 ${monsterName}（${details.join(' ')}）`, 'combat');
+    } else {
+      const details: string[] = [];
+      const hpLost = playerHpBefore - result.playerHpLeft;
+      if (hpLost > 0) details.push(`-${hpLost}HP`);
+      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
+      if (result.bodyExpGained > 0) details.push(`+${result.bodyExpGained}体修`);
+      addLog(`⚔️ 与 ${monsterName} 缠斗超时，双方脱战（${details.join(' ')}）`, 'combat');
+    }
+    setCombatModal(null);
+
+    // T0040: 战斗后死亡弹窗/游戏结束
+    if (deathInfo?.triggered && !deathInfo.blocked && deathInfo.severity === 'severe') {
+      if (deathInfo.availableRevivals && deathInfo.availableRevivals.length > 0 && deathInfo.triggerDef) {
+        const p = playerRef.current;
+        const ds = p ? getDeathSystemState(p) : { deathCount: 0, lastDeathCause: null, revivalCount: 0, lifeSaverTriggered: [], isLooseImmortal: false };
+        setDeathModal({
+          triggerDef: deathInfo.triggerDef,
+          severity: deathInfo.severity,
+          availableRevivals: deathInfo.availableRevivals,
+          playerSnapshot: {
+            name: p?.name ?? '',
+            realmIndex: p?.realmIndex ?? 0,
+            age: p?.age ?? 0,
+            killCount: p?.tracking.killCount ?? 0,
+            deathCount: ds.deathCount,
+          },
+        });
+      } else {
+        setGameOver(true);
+        setGameOverReason(deathInfo.triggerDef?.description ?? '战斗中身亡');
+      }
+    }
+  }, [addLog, playerRef, setGameOver, setGameOverReason, setDeathModal]);
+
+  return { combatModal, onCombatResult, handleCombatNext, handleCombatClose };
+}

--- a/src/hooks/useGameEngine.ts
+++ b/src/hooks/useGameEngine.ts
@@ -1,130 +1,31 @@
 // ============================================================
 // useGameEngine.ts — 游戏核心引擎 Hook（状态管理 + 存档 + 编排）
-// 行为逻辑已拆分至 useCoreActions.ts / useSystemActions.ts
+// 拆分结构：
+//   useSaveLoad.ts     — 存档读写 + 向后兼容
+//   useCoreActions.ts  — 修炼/战斗/探索/休息
+//   useSystemActions.ts — 炼丹/装备/商店/突破/功法等
+//   useCombatModal.ts  — 战斗弹窗状态 + 回调
 // ============================================================
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { createPlayer, getSpiritRootGrade, getSpiritRootDisplay } from '../game/player';
-import type { Player, Aptitudes } from '../game/player';
+import { createPlayer, getSpiritRootDisplay } from '../game/player';
+import type { Player } from '../game/player';
 import type { CreatePlayerOptions } from '../game/player';
-import { rollSpiritRoots } from '../game/spirit-root';
-import type { PlayerSpiritRoots, SpiritRootType, SpiritRootCombo } from '../game/spirit-root';
 import { REALMS, ACTION_COSTS } from '../game/data';
 import { registerCoreEvents, triggerDailyEvent } from '../game/events';
 import type { LogCategory } from './useGameLog';
 import { useToast } from './useToast';
 import { useCoreActions } from './useCoreActions';
-import type { LootEntry, CombatDeathInfo } from './useCoreActions';
 import { useSystemActions } from './useSystemActions';
-import type { CombatResult } from '../game/combat';
-import type { RoundSnapshot } from '../game/combat/types';
+import { useCombatModal } from './useCombatModal';
+import type { DeathModalState } from './useCombatModal';
 import { checkDeathTriggers, applyDeath, applyRevival, getDeathSystemState } from '../game/death';
-import type { DeathCheckResult, DeathResult } from '../game/death';
-import type { DeathTriggerDef, DeathSeverity, RevivalMethodDef } from '../game/types';
+import type { RevivalMethodDef } from '../game/types';
 import { checkAchievements } from '../game/achievement/engine';
+import { SAVE_KEY, loadSave, writeSave } from './useSaveLoad';
 
-// 注册状态由 useGameEngine 内部管理，通过 useEffect 异步加载
-
-export interface CombatModalState {
-  phase: 'battle' | 'loot';
-  monsterName: string;
-  monsterEmoji: string;
-  result: CombatResult;
-  loot: LootEntry[];
-  deathInfo?: CombatDeathInfo;
-  playerHpBefore: number;
-  playerMpBefore: number;
-  playerAvatar: string;
-  playerName: string;
-  playerRealmIndex: number;
-  playerMaxHp: number;
-  playerMaxMp: number;
-  monsterMaxHp: number;
-  snapshots: RoundSnapshot[];
-}
-
-export interface DeathModalState {
-  triggerDef: DeathTriggerDef;
-  severity: DeathSeverity;
-  availableRevivals: RevivalMethodDef[];
-  playerSnapshot: {
-    name: string;
-    realmIndex: number;
-    age: number;
-    killCount: number;
-    deathCount: number;
-  };
-}
-
-const SAVE_KEY = 'xiuxian_save';
-
-// ── T0056: 向后兼容——从旧资质推导灵根 ──
-function deriveCompatSpiritRoots(aptitudes: Aptitudes): PlayerSpiritRoots {
-  const grade = getSpiritRootGrade(aptitudes);
-  const gradeToCombo: Record<string, { combo: SpiritRootCombo; mult: number }> = {
-    '单灵根': { combo: 'single', mult: 3.0 },
-    '天灵根': { combo: 'dual',   mult: 2.0 },
-    '异灵根': { combo: 'triple', mult: 1.2 },
-    '灵根':   { combo: 'quad',   mult: 0.8 },
-    '杂灵根': { combo: 'penta',  mult: 0.5 },
-    '废灵根': { combo: 'none',   mult: 0.1 },
-  };
-  const mapping = gradeToCombo[grade.grade] ?? { combo: 'penta' as SpiritRootCombo, mult: 0.5 };
-  const elementMap: Array<{ type: SpiritRootType; val: number }> = [
-    { type: 'fire',  val: aptitudes.fire },
-    { type: 'water', val: aptitudes.water },
-    { type: 'earth', val: aptitudes.earth },
-    { type: 'wood',  val: aptitudes.wood },
-    { type: 'metal', val: (aptitudes.thunder + aptitudes.wind) / 2 },
-  ];
-  elementMap.sort((a, b) => b.val - a.val);
-  const comboCount: Record<SpiritRootCombo, number> = { none: 0, single: 1, dual: 2, triple: 3, quad: 4, penta: 5 };
-  const count = comboCount[mapping.combo];
-  const roots = elementMap.slice(0, count).map(e => ({ type: e.type, affinity: Math.min(100, Math.round(e.val)) }));
-  return { roots, combo: mapping.combo, cultivationMultiplier: mapping.mult };
-}
-
-function loadSave(): Player | null {
-  try {
-    const raw = localStorage.getItem(SAVE_KEY);
-    if (!raw) return null;
-    const p = JSON.parse(raw) as Player;
-    // 向后兼容：旧存档缺少 inventory/equipped 字段
-    if (!Array.isArray(p.inventory)) p.inventory = [];
-    if (!p.inventoryCapacity) p.inventoryCapacity = 20 + (p.realmIndex || 0) * 5;
-    if (!p.equipped) p.equipped = { weapon: null, helmet: null, armor: null, boots: null, accessory1: null, accessory2: null };
-    if (!p.avatar) p.avatar = 'default';
-    if (!Array.isArray(p.techniques)) p.techniques = [];
-    if (p.activeTechniqueId === undefined) p.activeTechniqueId = null;
-    // T0042: 历法向后兼容
-    if (!p.gameYear) {
-      const elapsed = p.age - 16;
-      p.gameYear = Math.max(1, Math.floor(elapsed) + 1);
-      p.gameMonth = Math.max(1, Math.min(12, Math.floor((elapsed - Math.floor(elapsed)) * 12) + 1));
-    }
-    // T0040: tracking 向后兼容
-    if (p.tracking) {
-      if (p.tracking.lowMoodStreak === undefined) p.tracking.lowMoodStreak = 0;
-      if (p.tracking.consecutiveBreakthroughFails === undefined) p.tracking.consecutiveBreakthroughFails = 0;
-    }
-    // T0056: 灵根 + 性别 + 外貌向后兼容
-    if (!p.spiritRoots) {
-      p.spiritRoots = deriveCompatSpiritRoots(p.aptitudes);
-    }
-    if (!p.gender) p.gender = 'male';
-    if (p.appearance === undefined) p.appearance = 0;
-    // T0031: achievement 向后兼容
-    if (!p.systems) p.systems = {};
-    if (!p.systems.achievement) {
-      p.systems.achievement = { unlockedIds: [], pendingToast: [] };
-    }
-    return p;
-  } catch { return null; }
-}
-
-function writeSave(player: Player): void {
-  localStorage.setItem(SAVE_KEY, JSON.stringify(player));
-}
+// Re-export types so existing imports still work
+export type { CombatModalState, DeathModalState } from './useCombatModal';
 
 export function useGameEngine(
   rawAddLog: (msg: string, category?: LogCategory, gameYear?: number, gameMonth?: number) => void,
@@ -133,7 +34,6 @@ export function useGameEngine(
   const [player, setPlayer] = useState<Player | null>(null);
   const [gameOver, setGameOver] = useState(false);
   const [gameOverReason, setGameOverReason] = useState('');
-  const [combatModal, setCombatModal] = useState<CombatModalState | null>(null);
   const [deathModal, setDeathModal] = useState<DeathModalState | null>(null);
   const [dataReady, setDataReady] = useState(false);
   const [dataError, setDataError] = useState(false);
@@ -262,6 +162,40 @@ export function useGameEngine(
       updated.tracking = { ...updated.tracking, lowMoodStreak: 0 };
     }
 
+    // ── 死亡检测通用辅助 ──
+    // 心魔/健康耗尽共用同一套 check → block/death → modal/gameOver 流程
+    const runDeathCheck = (p: Player, source: 'time' | 'combat' | 'other'): Player => {
+      const deathCheck = checkDeathTriggers(p, { source });
+      if (!deathCheck.triggered) return p;
+      if (deathCheck.blocked) {
+        for (const log of deathCheck.logs) addLog(log, 'system');
+        return deathCheck.player;
+      }
+      const death = applyDeath(p, deathCheck.trigger!);
+      for (const log of death.logs) addLog(log, 'system');
+      if (death.gameOver) {
+        if (death.availableRevivals.length > 0) {
+          const ds = getDeathSystemState(death.player);
+          setDeathModal({
+            triggerDef: deathCheck.trigger!,
+            severity: death.severity,
+            availableRevivals: death.availableRevivals,
+            playerSnapshot: {
+              name: death.player.name,
+              realmIndex: death.player.realmIndex,
+              age: death.player.age,
+              killCount: death.player.tracking.killCount,
+              deathCount: ds.deathCount,
+            },
+          });
+        } else {
+          setGameOver(true);
+          setGameOverReason(death.gameOverReason);
+        }
+      }
+      return death.player;
+    };
+
     // T0040: 寿元耗尽检查（通过死亡系统）
     if (updated.lifespan !== Infinity && updated.age >= updated.lifespan) {
       const deathCheck = checkDeathTriggers(updated, { source: 'time' });
@@ -278,72 +212,12 @@ export function useGameEngine(
     if (!gameOver && updated.mood <= 10
       && (updated.tracking.lowMoodStreak ?? 0) >= 5
       && (updated.tracking.consecutiveBreakthroughFails ?? 0) >= 3) {
-      const demonCheck = checkDeathTriggers(updated, { source: 'other' });
-      if (demonCheck.triggered) {
-        if (demonCheck.blocked) {
-          updated = demonCheck.player;
-          for (const log of demonCheck.logs) addLog(log, 'system');
-        } else {
-          const death = applyDeath(updated, demonCheck.trigger!);
-          updated = death.player;
-          for (const log of death.logs) addLog(log, 'system');
-          if (death.gameOver) {
-            if (death.availableRevivals.length > 0) {
-              const ds = getDeathSystemState(updated);
-              setDeathModal({
-                triggerDef: demonCheck.trigger!,
-                severity: death.severity,
-                availableRevivals: death.availableRevivals,
-                playerSnapshot: {
-                  name: updated.name,
-                  realmIndex: updated.realmIndex,
-                  age: updated.age,
-                  killCount: updated.tracking.killCount,
-                  deathCount: ds.deathCount,
-                },
-              });
-            } else {
-              setGameOver(true);
-              setGameOverReason(death.gameOverReason);
-            }
-          }
-        }
-      }
+      updated = runDeathCheck(updated, 'other');
     }
 
     // T0040: 健康耗尽检查
     if (!gameOver && updated.health <= 0) {
-      const healthCheck = checkDeathTriggers(updated, { source: 'other' });
-      if (healthCheck.triggered) {
-        if (healthCheck.blocked) {
-          updated = healthCheck.player;
-          for (const log of healthCheck.logs) addLog(log, 'system');
-        } else {
-          const death = applyDeath(updated, healthCheck.trigger!);
-          updated = death.player;
-          for (const log of death.logs) addLog(log, 'system');
-          if (death.gameOver) {
-            if (death.availableRevivals.length > 0) {
-              const ds = getDeathSystemState(updated);
-              setDeathModal({
-                triggerDef: healthCheck.trigger!,
-                severity: death.severity,
-                availableRevivals: death.availableRevivals,
-                playerSnapshot: {
-                  name: updated.name,
-                  realmIndex: updated.realmIndex,
-                  age: updated.age,
-                  killCount: updated.tracking.killCount,
-                  deathCount: ds.deathCount,
-                },
-              });
-            } else {
-              setGameOver(true);
-              setGameOverReason(death.gameOverReason);
-            }
-          }
-        }
-      }
+      updated = runDeathCheck(updated, 'other');
     }
 
     // B-4: 日常事件（每次时间推进时有概率触发）
@@ -364,97 +238,9 @@ export function useGameEngine(
     return player.stamina >= cost.stamina;
   }, [player, gameOver]);
 
-  // ── 战斗弹窗回调（T0044 + T0040）──
-  const onCombatResult = useCallback((monsterName: string, monsterEmoji: string, result: CombatResult, loot: LootEntry[], deathInfo?: CombatDeathInfo, hpBefore?: number, mpBefore?: number) => {
-    const p = playerRef.current;
-    setCombatModal({
-      phase: 'battle',
-      monsterName,
-      monsterEmoji,
-      result,
-      loot,
-      deathInfo,
-      playerHpBefore: hpBefore ?? 0,
-      playerMpBefore: mpBefore ?? 0,
-      playerAvatar: p?.avatar ?? 'default',
-      playerName: p?.name ?? '',
-      playerRealmIndex: p?.realmIndex ?? 0,
-      playerMaxHp: p?.maxHp ?? 100,
-      playerMaxMp: p?.maxMp ?? 30,
-      monsterMaxHp: result.monsterMaxHp,
-      snapshots: result.snapshots,
-    });
-  }, []);
-
-  const handleCombatNext = useCallback(() => {
-    setCombatModal(prev => prev ? { ...prev, phase: 'loot' } : null);
-  }, []);
-
-  const combatModalRef = useRef<CombatModalState | null>(null);
-  useEffect(() => { combatModalRef.current = combatModal; }, [combatModal]);
-
-  const handleCombatClose = useCallback(() => {
-    const modal = combatModalRef.current;
-    if (!modal) return;
-    const { monsterName, result, loot, deathInfo, playerHpBefore, playerMpBefore } = modal;
-
-    if (result.winner === 'player') {
-      const details: string[] = [];
-      if (result.expGained > 0) details.push(`+${result.expGained}修为`);
-      if (result.goldGained > 0) details.push(`+${result.goldGained}灵石`);
-      if (result.bodyExpGained > 0) details.push(`+${result.bodyExpGained}体修`);
-      const hpLost = playerHpBefore - result.playerHpLeft;
-      if (hpLost > 0) details.push(`-${hpLost}HP`);
-      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
-      if (loot.length > 0) details.push(`获得: ${loot.map(l => `${l.name}×${l.amount}`).join(' ')}`);
-      addLog(`⚔️ 击败 ${monsterName}（${details.join(' ')}）`, 'combat');
-    } else if (result.winner === 'monster') {
-      const details: string[] = [];
-      const hpLost = playerHpBefore - result.playerHpLeft;
-      if (hpLost > 0) details.push(`-${hpLost}HP`);
-      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
-      if (result.bodyExpGained > 0) details.push(`+${result.bodyExpGained}体修`);
-      if (deathInfo?.blocked) {
-        details.push(`${deathInfo.saverName ?? '护命道具'}救回一命`);
-      } else if (deathInfo?.triggered && deathInfo.penaltyLogs?.length) {
-        details.push(...deathInfo.penaltyLogs);
-      } else {
-        details.push('-20健康');
-      }
-      addLog(`💀 败于 ${monsterName}（${details.join(' ')}）`, 'combat');
-    } else {
-      const details: string[] = [];
-      const hpLost = playerHpBefore - result.playerHpLeft;
-      if (hpLost > 0) details.push(`-${hpLost}HP`);
-      if (result.mpUsed > 0) details.push(`-${result.mpUsed}MP`);
-      if (result.bodyExpGained > 0) details.push(`+${result.bodyExpGained}体修`);
-      addLog(`⚔️ 与 ${monsterName} 缠斗超时，双方脱战（${details.join(' ')}）`, 'combat');
-    }
-    setCombatModal(null);
-
-    // T0040: 战斗后死亡弹窗/游戏结束
-    if (deathInfo?.triggered && !deathInfo.blocked && deathInfo.severity === 'severe') {
-      if (deathInfo.availableRevivals && deathInfo.availableRevivals.length > 0 && deathInfo.triggerDef) {
-        const p = playerRef.current;
-        const ds = p ? getDeathSystemState(p) : { deathCount: 0, lastDeathCause: null, revivalCount: 0, lifeSaverTriggered: [], isLooseImmortal: false };
-        setDeathModal({
-          triggerDef: deathInfo.triggerDef,
-          severity: deathInfo.severity,
-          availableRevivals: deathInfo.availableRevivals,
-          playerSnapshot: {
-            name: p?.name ?? '',
-            realmIndex: p?.realmIndex ?? 0,
-            age: p?.age ?? 0,
-            killCount: p?.tracking.killCount ?? 0,
-            deathCount: ds.deathCount,
-          },
-        });
-      } else {
-        setGameOver(true);
-        setGameOverReason(deathInfo.triggerDef?.description ?? '战斗中身亡');
-      }
-    }
-  }, [addLog]);
+  // ── 战斗弹窗（拆分至 useCombatModal.ts）──
+  const { combatModal, onCombatResult, handleCombatNext, handleCombatClose } =
+    useCombatModal(playerRef, addLog, setGameOver, setGameOverReason, setDeathModal);
 
   // ── 子 Hook：核心行为（修炼/战斗/探索/休息）──
   const { cultivate, fight, explore, rest } = useCoreActions({

--- a/src/hooks/useSaveLoad.ts
+++ b/src/hooks/useSaveLoad.ts
@@ -1,0 +1,78 @@
+// ============================================================
+// useSaveLoad.ts — 存档读写 + 向后兼容处理
+// 从 useGameEngine.ts 拆出的纯工具函数
+// ============================================================
+
+import type { Player, Aptitudes } from '../game/player';
+import { getSpiritRootGrade } from '../game/player';
+import type { PlayerSpiritRoots, SpiritRootType, SpiritRootCombo } from '../game/spirit-root';
+
+export const SAVE_KEY = 'xiuxian_save';
+
+/** T0056: 向后兼容——从旧资质推导灵根 */
+function deriveCompatSpiritRoots(aptitudes: Aptitudes): PlayerSpiritRoots {
+  const grade = getSpiritRootGrade(aptitudes);
+  const gradeToCombo: Record<string, { combo: SpiritRootCombo; mult: number }> = {
+    '单灵根': { combo: 'single', mult: 3.0 },
+    '天灵根': { combo: 'dual',   mult: 2.0 },
+    '异灵根': { combo: 'triple', mult: 1.2 },
+    '灵根':   { combo: 'quad',   mult: 0.8 },
+    '杂灵根': { combo: 'penta',  mult: 0.5 },
+    '废灵根': { combo: 'none',   mult: 0.1 },
+  };
+  const mapping = gradeToCombo[grade.grade] ?? { combo: 'penta' as SpiritRootCombo, mult: 0.5 };
+  const elementMap: Array<{ type: SpiritRootType; val: number }> = [
+    { type: 'fire',  val: aptitudes.fire },
+    { type: 'water', val: aptitudes.water },
+    { type: 'earth', val: aptitudes.earth },
+    { type: 'wood',  val: aptitudes.wood },
+    { type: 'metal', val: (aptitudes.thunder + aptitudes.wind) / 2 },
+  ];
+  elementMap.sort((a, b) => b.val - a.val);
+  const comboCount: Record<SpiritRootCombo, number> = { none: 0, single: 1, dual: 2, triple: 3, quad: 4, penta: 5 };
+  const count = comboCount[mapping.combo];
+  const roots = elementMap.slice(0, count).map(e => ({ type: e.type, affinity: Math.min(100, Math.round(e.val)) }));
+  return { roots, combo: mapping.combo, cultivationMultiplier: mapping.mult };
+}
+
+export function loadSave(): Player | null {
+  try {
+    const raw = localStorage.getItem(SAVE_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as Player;
+    // 向后兼容：旧存档缺少 inventory/equipped 字段
+    if (!Array.isArray(p.inventory)) p.inventory = [];
+    if (!p.inventoryCapacity) p.inventoryCapacity = 20 + (p.realmIndex || 0) * 5;
+    if (!p.equipped) p.equipped = { weapon: null, helmet: null, armor: null, boots: null, accessory1: null, accessory2: null };
+    if (!p.avatar) p.avatar = 'default';
+    if (!Array.isArray(p.techniques)) p.techniques = [];
+    if (p.activeTechniqueId === undefined) p.activeTechniqueId = null;
+    // T0042: 历法向后兼容
+    if (!p.gameYear) {
+      const elapsed = p.age - 16;
+      p.gameYear = Math.max(1, Math.floor(elapsed) + 1);
+      p.gameMonth = Math.max(1, Math.min(12, Math.floor((elapsed - Math.floor(elapsed)) * 12) + 1));
+    }
+    // T0040: tracking 向后兼容
+    if (p.tracking) {
+      if (p.tracking.lowMoodStreak === undefined) p.tracking.lowMoodStreak = 0;
+      if (p.tracking.consecutiveBreakthroughFails === undefined) p.tracking.consecutiveBreakthroughFails = 0;
+    }
+    // T0056: 灵根 + 性别 + 外貌向后兼容
+    if (!p.spiritRoots) {
+      p.spiritRoots = deriveCompatSpiritRoots(p.aptitudes);
+    }
+    if (!p.gender) p.gender = 'male';
+    if (p.appearance === undefined) p.appearance = 0;
+    // T0031: achievement 向后兼容
+    if (!p.systems) p.systems = {};
+    if (!p.systems.achievement) {
+      p.systems.achievement = { unlockedIds: [], pendingToast: [] };
+    }
+    return p;
+  } catch { return null; }
+}
+
+export function writeSave(player: Player): void {
+  localStorage.setItem(SAVE_KEY, JSON.stringify(player));
+}


### PR DESCRIPTION
## 重构内容

`useGameEngine.ts` 从 538 行减到 324 行（-40%），拆出两个独立模块：

| 文件 | 行数 | 职责 |
|------|------|------|
| `useSaveLoad.ts` | 78 | 存档读写 + 向后兼容迁移 |
| `useCombatModal.ts` | 150 | 战斗弹窗状态 + 日志 + 死亡弹窗 |

### 额外优化
- `advanceTime` 中重复的死亡检测代码（心魔/健康耗尽）抽取为 `runDeathCheck` 辅助函数
- 类型通过 `export type { ... } from '...'` re-export，外部导入路径不变

纯重构，无功能变更。