### PR TITLE
fix: 修复详细属性双弹窗 + 主菜单移至右上角 + 精简左栏

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -526,6 +526,7 @@ body {
   gap: 0.6rem;
   height: fit-content;
   max-height: calc(100vh - 6vh);
+  overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: #333 #12162a;
 }
@@ -2120,7 +2121,7 @@ body {
 .debug-panel {
   position: fixed;
   top: 0.5rem;
-  right: 0.5rem;
+  right: 6rem;
   z-index: 999;
   max-width: 360px;
 }
@@ -2130,13 +2131,30 @@ body {
   color: #ef5350;
   border: 1px solid #ef5350;
   border-radius: 6px;
-  padding: 0.3rem 0.8rem;
-  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
   cursor: pointer;
   float: right;
 }
 
 .debug-toggle:hover { background: #3a1a1a; }
+
+/* 主菜单按钮（右上角，调试按钮左侧） */
+.exit-toggle {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 999;
+  background: #0a1a2a;
+  color: #90CAF9;
+  border: 1px solid #42A5F5;
+  border-radius: 6px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.exit-toggle:hover { background: #1a2a3a; }
 
 .debug-content {
   clear: both;
@@ -3419,23 +3437,6 @@ body {
   display: flex;
   gap: 10px;
   justify-content: center;
-}
-
-/* 主菜单按钮 */
-.left-exit-btn {
-  width: 100%;
-  margin-top: 8px;
-  background: #1a1e30 !important;
-  color: #888 !important;
-  border: 1px solid #333 !important;
-  font-size: 0.75rem !important;
-  padding: 5px 10px !important;
-}
-
-.left-exit-btn:hover {
-  background: #222840 !important;
-  color: #aaa !important;
-  border-color: #444 !important;
 }
 
 /* btn-danger */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,12 +68,12 @@ export default function App() {
     <>
       <GameLayout
         topBar={<ToastContainer toast={engine.toast} onDismiss={engine.dismissToast} />}
+        onExit={handleExitGame}
         left={
           <LeftPanel
             player={engine.player}
             activePanel={activePanel}
             onSelectPanel={handleSelectPanel}
-            onExit={handleExitGame}
           />
         }
         center={

--- a/src/components/layout/GameLayout.tsx
+++ b/src/components/layout/GameLayout.tsx
@@ -11,9 +11,10 @@ interface GameLayoutProps {
   right: ReactNode;
   topBar?: ReactNode;
   debug?: ReactNode;
+  onExit?: () => void;
 }
 
-export default function GameLayout({ left, center, right, topBar, debug }: GameLayoutProps) {
+export default function GameLayout({ left, center, right, topBar, debug, onExit }: GameLayoutProps) {
   return (
     <div className="game-layout-wrapper">
       {topBar && <div className="top-message-bar">{topBar}</div>}
@@ -22,6 +23,11 @@ export default function GameLayout({ left, center, right, topBar, debug }: GameL
         <main className="center-panel">{center}</main>
         <aside className="right-panel">{right}</aside>
       </div>
+      {onExit && (
+        <button className="exit-toggle" onClick={onExit} title="返回主菜单">
+          🏠 主菜单
+        </button>
+      )}
       {debug}
     </div>
   );

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -3,28 +3,25 @@
 // ============================================================
 
 import type { Player } from '../../game/player';
-import { REALMS, MONTH_NAMES } from '../../game/data';
+import { REALMS } from '../../game/data';
 import { getActiveBottlenecks, ensureBottleneckState } from '../../game/bottleneck';
 import { getNextRealm, formatAge } from '../../game/player';
 import { getNextBodyRealm } from '../../game/body-cultivation';
-import { getBodyRealmDef, getTechniqueDef, getDivineArtDef } from '../../game/registry';
-import { getDivineArtsState } from '../../game/divine-arts';
+import { getBodyRealmDef } from '../../game/registry';
 import { getCurrentRegion } from '../../game/map';
 import Avatar from './Avatar';
 import { CapacityBar, FloatingPanel, STAT_COLORS } from '../shared';
 import StatusPanel from '../panels/StatusPanel';
 import type { PanelKey } from './PanelButtons';
 import { UI_LABELS } from '../../data/texts/ui-labels';
-import { NOT_EQUIPPED } from '../../data/texts/common';
 
 interface LeftPanelProps {
   player: Player;
   activePanel: PanelKey | null;
   onSelectPanel: (key: PanelKey) => void;
-  onExit?: () => void;
 }
 
-export default function LeftPanel({ player, activePanel, onSelectPanel, onExit }: LeftPanelProps) {
+export default function LeftPanel({ player, activePanel, onSelectPanel }: LeftPanelProps) {
   const realm = REALMS[player.realmIndex];
   const nextRealm = getNextRealm(player);
   const expProgress = nextRealm
@@ -40,10 +37,6 @@ export default function LeftPanel({ player, activePanel, onSelectPanel, onExit }
   const pWithBn = ensureBottleneckState(player);
   const activeBns = getActiveBottlenecks(pWithBn);
 
-  // 当前激活的功法和神通
-  const activeTech = player.activeTechniqueId ? getTechniqueDef(player.activeTechniqueId) : null;
-  const divineState = getDivineArtsState(player);
-  const activeArt = divineState.activeArtId ? getDivineArtDef(divineState.activeArtId) : null;
   const currentRegion = getCurrentRegion(player);
 
   return (
@@ -96,20 +89,6 @@ export default function LeftPanel({ player, activePanel, onSelectPanel, onExit }
         </div>
         <CapacityBar current={player.stamina} max={player.maxStamina} color={STAT_COLORS.stamina} />
 
-        {/* 当前功法 & 神通 */}
-        <div className="left-stat-row">
-          <span>{UI_LABELS.stats.technique}</span>
-          <span style={{ color: activeTech ? '#4FC3F7' : '#666' }}>
-            {activeTech ? activeTech.name : NOT_EQUIPPED}
-          </span>
-        </div>
-        <div className="left-stat-row">
-          <span>{UI_LABELS.stats.divine}</span>
-          <span style={{ color: activeArt ? '#CE93D8' : '#666' }}>
-            {activeArt ? activeArt.name : NOT_EQUIPPED}
-          </span>
-        </div>
-
         {/* T0062 体魄条 */}
         <div className="left-stat-row">
           <span>{UI_LABELS.stats.physique}</span>
@@ -120,11 +99,6 @@ export default function LeftPanel({ player, activePanel, onSelectPanel, onExit }
         <div className="left-stat-row">
           <span>{UI_LABELS.stats.lifespan}</span>
           <span>{formatAge(player.age)}/{player.lifespan === Infinity ? '∞' : Math.floor(player.lifespan / 12) + UI_LABELS.age}</span>
-        </div>
-
-        <div className="left-stat-row">
-          <span>{UI_LABELS.stats.calendar}</span>
-          <span>{UI_LABELS.yearPrefix}{player.gameYear}{UI_LABELS.yearSuffix} {MONTH_NAMES[(player.gameMonth || 1) - 1]}</span>
         </div>
 
         <div className="left-stat-row">
@@ -172,12 +146,6 @@ export default function LeftPanel({ player, activePanel, onSelectPanel, onExit }
         </FloatingPanel>
       )}
 
-      {/* T0038: 主菜单按钮 */}
-      {onExit && (
-        <button className="btn left-exit-btn" onClick={onExit} title="返回主菜单">
-          🏠 主菜单
-        </button>
-      )}
     </>
   );
 }

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -63,7 +63,7 @@ export default function RightPanel({
     <>
       <PanelButtons player={player} activePanel={activePanel} onSelect={onSelectPanel} />
 
-      {activePanel && panelLabel && (
+      {activePanel && activePanel !== 'status' && panelLabel && (
         <FloatingPanel
           title={panelLabel.title}
           icon={panelLabel.icon}


### PR DESCRIPTION
## 修复内容

- **详细属性双弹窗**：RightPanel 在 activePanel='status' 时渲染了空 FloatingPanel，加排除条件修复
- **主菜单按钮移至右上角**：从左栏底部移到右上角固定位置，和调试按钮并排（主菜单在最右，调试在其左）
- **精简左栏**：去掉功法/神通/历法显示，减轻信息密度
- **左面板溢出**：增加 overflow-y: auto 防止内容被裁剪