### PR TITLE
fix(T0068): 修复履历事件记录丢失 + 新增任务完成事件

### DIFF
--- a/src/components/panels/ChroniclePanel.css
+++ b/src/components/panels/ChroniclePanel.css
@@ -16,111 +16,39 @@
   padding: var(--spacing-2xl);
 }
 
-/* ── 轮回卡片 ── */
+/* ── 角色摘要 ── */
 
-.chronicle-card {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  background: var(--color-bg-darkest);
-  overflow: hidden;
-}
-
-.chronicle-card-header {
+.chronicle-summary {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-md) var(--spacing-lg);
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.chronicle-card-header:hover {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.chronicle-card-header.expanded {
-  border-bottom: 1px solid var(--color-border);
-}
-
-.chronicle-card-main {
-  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--color-bg-darkest);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
 }
 
-.chronicle-card-no {
-  color: var(--color-text-dim);
-  font-size: var(--font-size-xs);
-  min-width: 28px;
-}
-
-.chronicle-card-name {
+.chronicle-summary-name {
   color: var(--color-text-white);
   font-weight: bold;
   font-size: var(--font-size-md);
 }
 
-.chronicle-card-realm {
+.chronicle-summary-realm {
   color: var(--color-text-gold);
   font-size: var(--font-size-sm);
 }
 
-.chronicle-card-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
-  font-size: var(--font-size-xs);
-}
-
-.chronicle-outcome {
-  padding: var(--spacing-xs) var(--spacing-md);
-  border-radius: var(--radius-sm);
-  font-weight: bold;
-}
-
-.outcome-died {
-  color: var(--color-text-danger);
-  background: rgba(255, 68, 68, 0.1);
-  border: 1px solid rgba(255, 68, 68, 0.3);
-}
-
-.outcome-ascended {
-  color: var(--color-text-gold);
-  background: rgba(255, 215, 0, 0.1);
-  border: 1px solid rgba(255, 215, 0, 0.3);
-}
-
-.outcome-active {
-  color: var(--color-text-success);
-  background: rgba(76, 175, 80, 0.1);
-  border: 1px solid rgba(76, 175, 80, 0.3);
-}
-
-.chronicle-card-age,
-.chronicle-card-duration {
-  color: var(--color-text-muted);
-}
-
-.chronicle-expand-arrow {
-  color: var(--color-text-dim);
-  font-size: var(--font-size-xs);
-  margin-left: var(--spacing-sm);
-}
-
-/* ── 详情区 ── */
-
-.chronicle-card-detail {
-  padding: var(--spacing-lg);
-}
-
-.chronicle-stats {
-  display: flex;
-  gap: var(--spacing-xl);
-  font-size: var(--font-size-xs);
+.chronicle-summary-age {
   color: var(--color-text-secondary);
-  margin-bottom: var(--spacing-lg);
-  padding-bottom: var(--spacing-md);
-  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
+}
+
+.chronicle-summary-stats {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin-left: auto;
 }
 
 .chronicle-no-events {

--- a/src/components/panels/ChroniclePanel.tsx
+++ b/src/components/panels/ChroniclePanel.tsx
@@ -1,11 +1,10 @@
 // ============================================================
 // ChroniclePanel.tsx — 修仙履历面板（T0068）
-// 展示跨局永久保存的修炼历程
+// 展示当前角色的关键事件时间线
 // ============================================================
 
 import './ChroniclePanel.css';
-import { useState } from 'react';
-import type { CultivationChronicle, IncarnationRecord, ChronicleEventType } from '../../game/chronicle';
+import type { CultivationChronicle, ChronicleEventType } from '../../game/chronicle';
 import { MONTH_NAMES } from '../../game/data';
 
 const EVENT_ICONS: Record<ChronicleEventType, string> = {
@@ -25,114 +24,58 @@ const EVENT_ICONS: Record<ChronicleEventType, string> = {
   game_over: '🏁',
 };
 
-const OUTCOME_LABELS: Record<string, { text: string; className: string }> = {
-  died: { text: '道消魂灭', className: 'outcome-died' },
-  ascended: { text: '羽化飞升', className: 'outcome-ascended' },
-  active: { text: '修炼中', className: 'outcome-active' },
-};
-
 interface ChroniclePanelProps {
   chronicle: CultivationChronicle;
 }
 
 export default function ChroniclePanel({ chronicle }: ChroniclePanelProps) {
-  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const record = chronicle.current;
 
-  const allRecords: IncarnationRecord[] = [];
-  if (chronicle.current) allRecords.push(chronicle.current);
-  allRecords.push(...[...chronicle.incarnations].reverse());
-
-  const toggleExpand = (no: number) => {
-    setExpandedId(prev => prev === no ? null : no);
-  };
-
-  if (allRecords.length === 0) {
+  if (!record) {
     return (
       <div className="chronicle-panel">
         <div className="chronicle-empty">
-          此生尚是第一轮回，修仙之路，从此启程。
+          修仙之路，从此启程。
         </div>
       </div>
     );
   }
 
+  const ageYears = Math.floor(record.finalAge / 12);
+
   return (
     <div className="chronicle-panel">
-      {allRecords.map(record => {
-        const isExpanded = expandedId === record.incarnationNo;
-        const isCurrent = record.outcome === 'active';
-        const outcome = OUTCOME_LABELS[record.outcome] ?? OUTCOME_LABELS.died;
-        const ageYears = Math.floor(record.finalAge / 12);
-        const ageMonths = record.finalAge % 12;
-        const duration = record.endGameYear && record.startGameYear
-          ? record.endGameYear - record.startGameYear
-          : null;
+      {/* 角色摘要 */}
+      <div className="chronicle-summary">
+        <span className="chronicle-summary-name">{record.characterName}</span>
+        <span className="chronicle-summary-realm">{record.finalRealmName}期</span>
+        <span className="chronicle-summary-age">{ageYears}岁</span>
+        <span className="chronicle-summary-stats">
+          击杀 {record.totalKills} · 死亡 {record.totalDeaths} · 复活 {record.totalRevives}
+        </span>
+      </div>
 
-        return (
-          <div key={record.incarnationNo} className="chronicle-card">
+      {/* 关键事件时间线 */}
+      {record.events.length === 0 ? (
+        <div className="chronicle-no-events">尚无关键事件记录</div>
+      ) : (
+        <div className="chronicle-timeline">
+          {record.events.map((event, idx) => (
             <div
-              className={`chronicle-card-header ${isExpanded ? 'expanded' : ''}`}
-              onClick={() => toggleExpand(record.incarnationNo)}
+              key={idx}
+              className={`chronicle-event ${event.type === 'death' ? 'chronicle-event-death' : ''} ${event.type === 'game_over' ? 'chronicle-event-end' : ''}`}
             >
-              <div className="chronicle-card-main">
-                <span className="chronicle-card-no">
-                  {isCurrent ? '📜' : `#${record.incarnationNo}`}
-                </span>
-                <span className="chronicle-card-name">{record.characterName}</span>
-                <span className="chronicle-card-realm">{record.finalRealmName}期</span>
-              </div>
-              <div className="chronicle-card-meta">
-                <span className={`chronicle-outcome ${outcome.className}`}>
-                  {outcome.text}
-                </span>
-                <span className="chronicle-card-age">
-                  {ageYears}岁{ageMonths > 0 ? `${ageMonths}月` : ''}
-                </span>
-                {duration !== null && (
-                  <span className="chronicle-card-duration">
-                    历{duration}年
-                  </span>
-                )}
-                <span className="chronicle-expand-arrow">{isExpanded ? '▼' : '▶'}</span>
-              </div>
+              <span className="chronicle-event-icon">
+                {EVENT_ICONS[event.type] ?? '📌'}
+              </span>
+              <span className="chronicle-event-time">
+                第{event.year}年 {MONTH_NAMES[event.month - 1] ?? `${event.month}月`}
+              </span>
+              <span className="chronicle-event-desc">{event.description}</span>
             </div>
-
-            {isExpanded && (
-              <div className="chronicle-card-detail">
-                <div className="chronicle-stats">
-                  <span>击杀: {record.totalKills}</span>
-                  <span>死亡: {record.totalDeaths}</span>
-                  <span>复活: {record.totalRevives}</span>
-                  {record.finalBodyRealmIndex > 0 && (
-                    <span>体修: 阶{record.finalBodyRealmIndex}</span>
-                  )}
-                </div>
-
-                {record.events.length === 0 ? (
-                  <div className="chronicle-no-events">暂无关键事件</div>
-                ) : (
-                  <div className="chronicle-timeline">
-                    {record.events.map((event, idx) => (
-                      <div
-                        key={idx}
-                        className={`chronicle-event ${event.type === 'death' ? 'chronicle-event-death' : ''} ${event.type === 'game_over' ? 'chronicle-event-end' : ''}`}
-                      >
-                        <span className="chronicle-event-icon">
-                          {EVENT_ICONS[event.type] ?? '📌'}
-                        </span>
-                        <span className="chronicle-event-time">
-                          第{event.year}年 {MONTH_NAMES[event.month - 1] ?? `${event.month}月`}
-                        </span>
-                        <span className="chronicle-event-desc">{event.description}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        );
-      })}
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useChronicle.ts
+++ b/src/hooks/useChronicle.ts
@@ -24,8 +24,9 @@ export function useChronicle() {
     chronicleRef.current = chronicle;
   }, [chronicle]);
 
-  // 持久化
+  // 持久化 — 同步更新 ref，确保连续调用不丢事件
   const persist = useCallback((c: CultivationChronicle) => {
+    chronicleRef.current = c;
     setChronicle(c);
     saveChronicle(c);
   }, []);

--- a/src/hooks/useGameEngine.ts
+++ b/src/hooks/useGameEngine.ts
@@ -111,10 +111,14 @@ export function useGameEngine(
       setGameOver(false);
       setGameOverReason('');
       addLog(UI_LABELS.loadSuccess(saved.name, REALMS[saved.realmIndex].name), 'system');
+      // T0068: 加载存档时确保有当前轮回
+      if (!chronicle.chronicle.current) {
+        chronicle.startNewIncarnation(withRegions);
+      }
       return true;
     }
     return false;
-  }, [addLog]);
+  }, [addLog, chronicle]);
 
   // 自动存档
   useEffect(() => {

--- a/src/hooks/useSystemActions.ts
+++ b/src/hooks/useSystemActions.ts
@@ -21,7 +21,7 @@ import { recalcStats } from '../game/player';
 import { REALMS } from '../game/data';
 import type { ChronicleEventType } from '../game/chronicle';
 import { checkDeathTriggers, applyDeath, getDeathSystemState } from '../game/death';
-import { getEquipDef, getTechniqueDef, getRecipe, getSmithingRecipe } from '../game/registry';
+import { getEquipDef, getTechniqueDef, getRecipe, getSmithingRecipe, getQuestChainDef } from '../game/registry';
 import { tickQuestObjectives, acceptQuest as acceptQuestFn, abandonQuest as abandonQuestFn, deliverQuestItem as deliverQuestItemFn, checkQuestDiscovery, setTrackedQuest as setTrackedQuestFn, turnInQuest as turnInQuestFn } from '../game/quest';
 import type { EquipSlot } from '../game/registry';
 import type { LogCategory } from './useGameLog';
@@ -193,7 +193,7 @@ export function useSystemActions(deps: SystemActionDeps) {
         addLog(BREAKTHROUGH_TEXTS.bottleneckHint, 'system');
       }
     }
-  }, [player, addLog, setPlayer, setGameOver, setGameOverReason]);
+  }, [player, addLog, setPlayer, setGameOver, setGameOverReason, chronicleHooks]);
 
   // ── T0017: 功法 ──
   const learn = useCallback((techniqueId: string) => {
@@ -334,10 +334,18 @@ export function useSystemActions(deps: SystemActionDeps) {
       if (!prev) return prev;
       const result = turnInQuestFn(prev, questId);
       questLogs = result.logs;
+      // T0068: 记录任务完成事件
+      if (result.logs.some(l => l.includes('🎉'))) {
+        const questDef = getQuestChainDef(questId);
+        chronicleHooks?.recordEvent('achievement_unlocked', result.player,
+          `完成任务「${questDef?.name ?? questId}」`,
+          { questId, questName: questDef?.name },
+        );
+      }
       return result.player;
     });
     setTimeout(() => { for (const log of questLogs) addLog(log, 'system'); }, 0);
-  }, [addLog, setPlayer]);
+  }, [addLog, setPlayer, chronicleHooks]);
 
   const setTrackedQuest = useCallback((questId: string | null) => {
     setPlayer(prev => {


### PR DESCRIPTION
## 修复内容

### 根本原因
`useChronicle` 的 `persist` 函数使用 `setChronicle`（异步）更新状态，但 `chronicleRef` 要等 `useEffect` 才同步。当 `startNewIncarnation` 和 `addEvent` 在同一渲染周期内被调用时，`addEvent` 读到的 ref 还是旧值（`current: null`），导致事件被静默丢弃。

### 修复
- `persist()` 中同步更新 `chronicleRef.current = c`
- `breakthrough` 的 `useCallback` 依赖加入 `chronicleHooks`
- `loadGame` 加载旧存档时初始化轮回记录

### 新增
- 任务交付成功时记录 `achievement_unlocked` 事件
- 简化 ChroniclePanel 为当前角色事件时间线