### PR TITLE
fix(ui): 修复右侧面板按钮拥挤溢出与移动端音效条遮挡

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -989,25 +989,26 @@ body {
 }
 
 .panel-btn-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(5.5rem, 1fr));
   gap: 0.3rem;
-  flex-wrap: wrap;
 }
 
 .panel-btn {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  justify-content: center;
+  gap: 0.25rem;
   background: #0e1020;
   border: 1px solid #1e2235;
   border-radius: 6px;
-  padding: 0.4rem 0.6rem;
+  padding: 0.4rem 0.45rem;
   color: #aaa;
   font-size: 0.78rem;
   cursor: pointer;
   transition: all 0.15s;
-  flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
 
 .panel-btn:hover {
@@ -1025,10 +1026,14 @@ body {
 
 .panel-btn-icon {
   font-size: 1rem;
+  flex-shrink: 0;
 }
 
 .panel-btn-label {
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 /* 右栏面板内容 */

--- a/src/components/hud/SoundControls.css
+++ b/src/components/hud/SoundControls.css
@@ -43,3 +43,20 @@
 .sound-volume input {
   width: calc(var(--spacing-3xl) * 3);
 }
+
+/* 窄屏:右侧面板变为底部抽屉,音效条改停靠左上角避免遮挡按钮 */
+@media (max-width: 959px) {
+  .sound-controls {
+    top: var(--spacing-lg);
+    left: var(--spacing-lg);
+    right: auto;
+    bottom: auto;
+    flex-wrap: wrap;
+    max-width: 60vw;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+  .sound-volume input {
+    width: calc(var(--spacing-3xl) * 2);
+  }
+}


### PR DESCRIPTION
## 问题
用户反馈网页上按钮显示有 bug:不对齐、溢出、一大堆 UI 问题。

经 Playwright 多视口截图复现,根因有二:

1. **右侧面板按钮挤成一行溢出**:.panel-btn-row 用 flex-wrap,但 .panel-btn 带 flex:1; min-width:0,迫使一组 8 个按钮(修行组)收缩到每个约 28px 挤在同一行,标签溢出重叠、最右按钮被裁切。
2. **移动端音效悬浮条遮挡按钮**:窄屏右栏变底部抽屉时,固定定位的音效条压住门派/世界等按钮。

## 修复
- panel-btn-row 改为响应式 grid:repeat(auto-fill, minmax(5.5rem, 1fr)),按钮整齐换行(桌面 2 列、平板满宽多列、移动多列)。
- panel-btn 移除 flex:1、居中并 overflow:hidden;panel-btn-label 增加 text-overflow:ellipsis 作兜底。
- <=959px 时音效条停靠左上角,避免遮挡底部抽屉按钮。

## 验证
Playwright 在 desktop(1280)/tablet(768)/mobile(390) 三视口截图确认:按钮整齐对齐、无溢出/裁切,音效条不再遮挡。